### PR TITLE
Add drag-and-drop reordering for session list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-web-links": "^0.11.0",
         "@xterm/xterm": "^5.5.0",
@@ -336,6 +339,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@electron-forge/cli": {
@@ -8505,6 +8561,12 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "0.21.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,7 @@ import type {
   SessionConfig,
   SessionIdPayload,
   SessionRenamePayload,
+  SessionReorderPayload,
   PtyWritePayload,
   PtyResizePayload,
   ToolkitCommand,
@@ -515,6 +516,13 @@ function registerIpcHandlers(): void {
       });
       sessionStore.persistSessions();
       return sessionStore.getSession(payload.id)!;
+    },
+  );
+
+  ipcMain.handle(
+    IpcChannels.SESSION_REORDER,
+    (_event, payload: SessionReorderPayload): void => {
+      sessionStore.reorderSessions(payload.sessionIds);
     },
   );
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -9,6 +9,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   sessionEnd: (id: string) => ipcRenderer.invoke('session:end', { id }),
   sessionSwitch: (id: string) => ipcRenderer.invoke('session:switch', { id }),
   sessionToggleNotify: (id: string) => ipcRenderer.invoke('session:toggle-notify', { id }),
+  sessionReorder: (sessionIds: string[]) => ipcRenderer.invoke('session:reorder', { sessionIds }),
 
   // PTY I/O
   ptyWrite: (sessionId: string, data: string) => ipcRenderer.invoke('pty:write', { sessionId, data }),

--- a/src/main/session-store.ts
+++ b/src/main/session-store.ts
@@ -115,6 +115,21 @@ export class SessionStore {
     return session;
   }
 
+  /** Reorder sessions to match the given ID order. */
+  reorderSessions(sessionIds: string[]): void {
+    const ordered = new Map<string, Session>();
+    for (const id of sessionIds) {
+      const session = this.sessions.get(id);
+      if (session) ordered.set(id, session);
+    }
+    // Append any sessions not in the list (shouldn't happen, but safe)
+    for (const [id, session] of this.sessions) {
+      if (!ordered.has(id)) ordered.set(id, session);
+    }
+    this.sessions = ordered;
+    this.persistSessionIndex();
+  }
+
   removeSession(id: string): void {
     this.sessions.delete(id);
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -208,6 +208,14 @@ export function App(): React.ReactElement {
     []
   );
 
+  const handleReorderSessions = useCallback(
+    (reorderedSessions: Session[]) => {
+      setSessions(reorderedSessions);
+      window.electronAPI.sessionReorder(reorderedSessions.map((s) => s.id));
+    },
+    []
+  );
+
   const handleRenameSession = useCallback(
     (id: string, newName: string) => {
       window.electronAPI.sessionRename(id, newName).then((updated) => {
@@ -363,6 +371,7 @@ export function App(): React.ReactElement {
             onRenameSession={handleRenameSession}
             onEndSession={requestEndSession}
             onToggleNotify={handleToggleNotify}
+            onReorderSessions={handleReorderSessions}
           />
 
           {/* Toolkit */}

--- a/src/renderer/components/SessionList.tsx
+++ b/src/renderer/components/SessionList.tsx
@@ -1,5 +1,19 @@
-import React, { useState, useCallback, useRef, useEffect } from 'react';
+import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { GitBranch, Bell, BellOff } from 'lucide-react';
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import type { Session } from '../../shared/types';
 
 interface SessionListProps {
@@ -10,6 +24,7 @@ interface SessionListProps {
   onRenameSession: (id: string, newName: string) => void;
   onEndSession: (id: string) => void;
   onToggleNotify: (id: string) => void;
+  onReorderSessions: (sessions: Session[]) => void;
 }
 
 const statusColors: Record<string, string> = {
@@ -39,10 +54,32 @@ export function SessionList({
   onRenameSession,
   onEndSession,
   onToggleNotify,
+  onReorderSessions,
 }: SessionListProps): React.ReactElement {
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  const sessionIds = useMemo(() => sessions.map((s) => s.id), [sessions]);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const oldIndex = sessions.findIndex((s) => s.id === active.id);
+      const newIndex = sessions.findIndex((s) => s.id === over.id);
+      if (oldIndex === -1 || newIndex === -1) return;
+      const reordered = [...sessions];
+      const [moved] = reordered.splice(oldIndex, 1);
+      reordered.splice(newIndex, 0, moved);
+      onReorderSessions(reordered);
+    },
+    [sessions, onReorderSessions],
+  );
 
   const handleContextMenu = useCallback(
     (e: React.MouseEvent, sessionId: string | null) => {
@@ -179,19 +216,23 @@ export function SessionList({
             </span>
           </div>
         ) : (
-          sessions.map((session) => (
-            <SessionCard
-              key={session.id}
-              session={session}
-              isActive={session.id === activeSessionId}
-              isEditing={session.id === editingSessionId}
-              onClick={() => onSelectSession(session.id)}
-              onContextMenu={(e) => handleContextMenu(e, session.id)}
-              onRenameCommit={(newName) => handleRenameCommit(session.id, newName)}
-              onRenameCancel={handleRenameCancel}
-              onToggleNotify={() => onToggleNotify(session.id)}
-            />
-          ))
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+            <SortableContext items={sessionIds} strategy={verticalListSortingStrategy}>
+              {sessions.map((session) => (
+                <SortableSessionCard
+                  key={session.id}
+                  session={session}
+                  isActive={session.id === activeSessionId}
+                  isEditing={session.id === editingSessionId}
+                  onClick={() => onSelectSession(session.id)}
+                  onContextMenu={(e) => handleContextMenu(e, session.id)}
+                  onRenameCommit={(newName) => handleRenameCommit(session.id, newName)}
+                  onRenameCancel={handleRenameCancel}
+                  onToggleNotify={() => onToggleNotify(session.id)}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
         )}
       </div>
 
@@ -234,6 +275,31 @@ interface SessionCardProps {
   onRenameCommit: (newName: string) => void;
   onRenameCancel: () => void;
   onToggleNotify: () => void;
+}
+
+function SortableSessionCard(props: SessionCardProps): React.ReactElement {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: props.session.id });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    position: 'relative' as const,
+    zIndex: isDragging ? 1 : 0,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      <SessionCard {...props} />
+    </div>
+  );
 }
 
 function SessionCard({ session, isActive, isEditing, onClick, onContextMenu, onRenameCommit, onRenameCancel, onToggleNotify }: SessionCardProps): React.ReactElement {

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -9,6 +9,7 @@ interface ElectronAPI {
   sessionEnd: (id: string) => Promise<void>;
   sessionSwitch: (id: string) => Promise<Session>;
   sessionToggleNotify: (id: string) => Promise<Session>;
+  sessionReorder: (sessionIds: string[]) => Promise<void>;
 
   // PTY I/O
   ptyWrite: (sessionId: string, data: string) => Promise<void>;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -13,6 +13,7 @@ export const IpcChannels = {
   SESSION_END: 'session:end',
   SESSION_SWITCH: 'session:switch',
   SESSION_TOGGLE_NOTIFY: 'session:toggle-notify',
+  SESSION_REORDER: 'session:reorder',
   // Session state updates (push: main → renderer)
   SESSION_STATE: 'session:state',
 
@@ -74,6 +75,7 @@ import type {
   SessionConfig,
   SessionIdPayload,
   SessionRenamePayload,
+  SessionReorderPayload,
   SessionStateUpdate,
   PtyDataPayload,
   PtyWritePayload,
@@ -96,6 +98,7 @@ export interface IpcInvokeMap {
   [IpcChannels.SESSION_END]: { payload: SessionIdPayload; response: void };
   [IpcChannels.SESSION_SWITCH]: { payload: SessionIdPayload; response: Session };
   [IpcChannels.SESSION_TOGGLE_NOTIFY]: { payload: SessionIdPayload; response: Session };
+  [IpcChannels.SESSION_REORDER]: { payload: SessionReorderPayload; response: void };
   [IpcChannels.PTY_WRITE]: { payload: PtyWritePayload; response: void };
   [IpcChannels.PTY_RESIZE]: { payload: PtyResizePayload; response: void };
   [IpcChannels.SHELL_WRITE]: { payload: PtyWritePayload; response: void };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -138,6 +138,10 @@ export interface ToolkitListPayload {
   sessionId?: string;
 }
 
+export interface SessionReorderPayload {
+  sessionIds: string[];
+}
+
 export interface ToolkitSavePayload {
   commands: ToolkitCommand[];
 }


### PR DESCRIPTION
## Summary

- Integrate `@dnd-kit/core` + `@dnd-kit/sortable` for drag-and-drop session reordering in the sidebar
- Add `session:reorder` IPC channel to persist new order to `~/.chorus/sessions.json`
- Use 5px activation distance on `PointerSensor` to distinguish clicks from drags

Closes #2

## Test plan

- [x] Create 3+ sessions and drag to reorder — verify order updates immediately
- [x] Restart the app — verify reordered sessions persist
- [x] Click a session without dragging — verify it still switches normally
- [x] Right-click context menu still works on session cards
- [x] `npm run build` passes, `npm test` passes (208 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)