### PR TITLE
Add Cmd+F terminal search with Cmd+G/Cmd+Shift+G navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-web-links": "^0.11.0",
         "@xterm/xterm": "^5.5.0",
         "lucide-react": "^1.7.0",
@@ -2929,6 +2930,12 @@
       "peerDependencies": {
         "@xterm/xterm": "^5.0.0"
       }
+    },
+    "node_modules/@xterm/addon-search": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-search/-/addon-search-0.16.0.tgz",
+      "integrity": "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==",
+      "license": "MIT"
     },
     "node_modules/@xterm/addon-web-links": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
     "lucide-react": "^1.7.0",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -389,6 +389,28 @@ function createMenu(): void {
         { role: "copy" },
         { role: "paste" },
         { role: "selectAll" },
+        { type: "separator" },
+        {
+          label: "Find",
+          accelerator: "CmdOrCtrl+F",
+          click: () => {
+            mainWindow?.webContents.send(IpcChannels.MENU_FIND);
+          },
+        },
+        {
+          label: "Find Next",
+          accelerator: "CmdOrCtrl+G",
+          click: () => {
+            mainWindow?.webContents.send(IpcChannels.MENU_FIND_NEXT);
+          },
+        },
+        {
+          label: "Find Previous",
+          accelerator: "CmdOrCtrl+Shift+G",
+          click: () => {
+            mainWindow?.webContents.send(IpcChannels.MENU_FIND_PREVIOUS);
+          },
+        },
       ],
     },
     {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -79,4 +79,19 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('menu:close-session', listener);
     return () => ipcRenderer.removeListener('menu:close-session', listener);
   },
+  onMenuFind: (callback: () => void) => {
+    const listener = () => callback();
+    ipcRenderer.on('menu:find', listener);
+    return () => ipcRenderer.removeListener('menu:find', listener);
+  },
+  onMenuFindNext: (callback: () => void) => {
+    const listener = () => callback();
+    ipcRenderer.on('menu:find-next', listener);
+    return () => ipcRenderer.removeListener('menu:find-next', listener);
+  },
+  onMenuFindPrevious: (callback: () => void) => {
+    const listener = () => callback();
+    ipcRenderer.on('menu:find-previous', listener);
+    return () => ipcRenderer.removeListener('menu:find-previous', listener);
+  },
 });

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -5,7 +5,8 @@ import { StatusBar } from './components/StatusBar';
 import { ShellPanel } from './components/ShellPanel';
 import { SessionList } from './components/SessionList';
 import { ToolkitPanel } from './components/ToolkitPanel';
-import { TerminalView, disposeTerminal, focusTerminal } from './components/TerminalView';
+import { TerminalView, disposeTerminal, focusTerminal, getFocusedTerminalInfo } from './components/TerminalView';
+import { SearchBar } from './components/SearchBar';
 import { NewSessionDialog } from './components/NewSessionDialog';
 
 const DEFAULT_SIDEBAR_WIDTH = 320;
@@ -20,6 +21,8 @@ export function App(): React.ReactElement {
   const [shellCollapsed, setShellCollapsed] = useState(false);
   const [showNewSession, setShowNewSession] = useState(false);
   const [endSessionConfirm, setEndSessionConfirm] = useState<string | null>(null);
+  const [search, setSearch] = useState<{ type: 'pty' | 'shell'; sessionId: string; key: number } | null>(null);
+  const searchKeyRef = useRef(0);
 
   // Panel sizes
   const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH);
@@ -113,6 +116,17 @@ export function App(): React.ReactElement {
         const currentId = activeSessionIdRef.current;
         if (currentId) setEndSessionConfirm(currentId);
       }),
+      window.electronAPI.onMenuFind(() => {
+        const currentId = activeSessionIdRef.current;
+        if (!currentId) return;
+        const k = ++searchKeyRef.current;
+        const focused = getFocusedTerminalInfo();
+        if (focused && focused.sessionId === currentId) {
+          setSearch({ type: focused.type, sessionId: focused.sessionId, key: k });
+        } else {
+          setSearch({ type: 'pty', sessionId: currentId, key: k });
+        }
+      }),
     ];
     return () => cleanups.forEach((c) => c());
   }, []);
@@ -139,6 +153,7 @@ export function App(): React.ReactElement {
   const handleSelectSession = useCallback(
     (id: string) => {
       setActiveSessionId(id);
+      setSearch(null);
       window.electronAPI.sessionSwitch(id);
       window.electronAPI.appSaveState({ lastActiveSessionId: id });
     },
@@ -309,6 +324,10 @@ export function App(): React.ReactElement {
           from { opacity: 0; transform: translateY(8px); }
           to { opacity: 1; transform: translateY(0); }
         }
+        @keyframes slideDown {
+          from { opacity: 0; transform: translateY(-8px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
         /* Context menu item hover + focus */
         [role="menuitem"]:hover,
         [role="menuitem"]:focus {
@@ -327,8 +346,17 @@ export function App(): React.ReactElement {
         onResize={handleSidebarResize}
       >
         {/* LEFT PANE: status bar + terminal + shell */}
-        <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden', position: 'relative' }}>
           <StatusBar session={activeSession} />
+
+          {search && (
+            <SearchBar
+              key={search.key}
+              type={search.type}
+              sessionId={search.sessionId}
+              onClose={() => setSearch(null)}
+            />
+          )}
 
           <SplitPane
             direction="vertical"

--- a/src/renderer/components/SearchBar.tsx
+++ b/src/renderer/components/SearchBar.tsx
@@ -1,0 +1,167 @@
+import React, { useRef, useEffect, useState, useCallback } from 'react';
+import {
+  terminalFindNext,
+  terminalFindPrevious,
+  terminalClearSearch,
+} from './TerminalView';
+
+interface SearchBarProps {
+  type: 'pty' | 'shell';
+  sessionId: string;
+  onClose: () => void;
+}
+
+export function SearchBar({ type, sessionId, onClose }: SearchBarProps): React.ReactElement {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [query, setQuery] = useState('');
+  const [resultCount, setResultCount] = useState(0);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  useEffect(() => {
+    if (query) {
+      const { resultCount: count } = terminalFindNext(type, sessionId, query);
+      setResultCount(count);
+    } else {
+      terminalClearSearch(type, sessionId);
+      setResultCount(0);
+    }
+  }, [query, type, sessionId]);
+
+  const queryRef = useRef(query);
+  queryRef.current = query;
+
+  const handleNext = useCallback(() => {
+    if (queryRef.current) {
+      const { resultCount: count } = terminalFindNext(type, sessionId, queryRef.current);
+      setResultCount(count);
+    }
+  }, [type, sessionId]);
+
+  const handlePrev = useCallback(() => {
+    if (queryRef.current) {
+      const { resultCount: count } = terminalFindPrevious(type, sessionId, queryRef.current);
+      setResultCount(count);
+    }
+  }, [type, sessionId]);
+
+  useEffect(() => {
+    const cleanups = [
+      window.electronAPI.onMenuFindNext(handleNext),
+      window.electronAPI.onMenuFindPrevious(handlePrev),
+    ];
+    return () => cleanups.forEach((c) => c());
+  }, [handleNext, handlePrev]);
+
+  const handleClose = useCallback(() => {
+    terminalClearSearch(type, sessionId);
+    onClose();
+  }, [type, sessionId, onClose]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      handleClose();
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (e.shiftKey) {
+        handlePrev();
+      } else {
+        handleNext();
+      }
+    }
+  }, [handleClose, handleNext, handlePrev]);
+
+  const resultText = query
+    ? resultCount > 0
+      ? `${resultCount} results`
+      : 'No results'
+    : '';
+
+  return (
+    <div style={containerStyle}>
+      <div style={barStyle}>
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Search..."
+          style={inputStyle}
+        />
+        {resultText && (
+          <span style={resultTextStyle}>{resultText}</span>
+        )}
+        <button onClick={handlePrev} style={btnStyle} title="Previous (Shift+Enter)">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path d="M2.5 7.5L6 4L9.5 7.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        </button>
+        <button onClick={handleNext} style={btnStyle} title="Next (Enter)">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path d="M2.5 4.5L6 8L9.5 4.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        </button>
+        <button onClick={handleClose} style={btnStyle} title="Close (Escape)">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path d="M3 3L9 9M9 3L3 9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const containerStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: 'calc(var(--status-bar-height) + 8px)',
+  right: 16,
+  zIndex: 100,
+  animation: 'slideDown 120ms ease',
+};
+
+const barStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4,
+  background: 'var(--bg-elevated)',
+  border: '1px solid var(--border-default)',
+  borderRadius: 'var(--radius-md)',
+  boxShadow: 'var(--shadow-md)',
+  padding: '4px 6px',
+};
+
+const inputStyle: React.CSSProperties = {
+  width: 180,
+  padding: '4px 8px',
+  fontSize: 12,
+  fontFamily: 'var(--font-ui)',
+  color: 'var(--text-primary)',
+  background: 'var(--bg-surface)',
+  border: '1px solid var(--border-subtle)',
+  borderRadius: 'var(--radius-sm)',
+};
+
+const resultTextStyle: React.CSSProperties = {
+  fontSize: 11,
+  color: 'var(--text-secondary)',
+  fontFamily: 'var(--font-ui)',
+  whiteSpace: 'nowrap',
+  minWidth: 60,
+  textAlign: 'center',
+};
+
+const btnStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 24,
+  height: 24,
+  borderRadius: 'var(--radius-sm)',
+  color: 'var(--text-secondary)',
+  transition: 'all var(--transition-fast)',
+  flexShrink: 0,
+};

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useEffect, useCallback } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
+import { SearchAddon } from '@xterm/addon-search';
 import '@xterm/xterm/css/xterm.css';
 
 interface TerminalViewProps {
@@ -13,6 +14,7 @@ interface TerminalViewProps {
 interface TerminalEntry {
   terminal: Terminal;
   fitAddon: FitAddon;
+  searchAddon: SearchAddon;
   mountedIn: HTMLElement | null;
   opened: boolean;
   removeDataListener: (() => void) | null;
@@ -42,6 +44,59 @@ export function disposeTerminal(type: 'pty' | 'shell', sessionId: string): void 
     entry.terminal.dispose();
     terminalCache.delete(key);
   }
+}
+
+// ─── Focus Tracking ─────────────────────────────────────
+let focusedTerminalKey: string | null = null;
+
+export function getFocusedTerminalInfo(): { type: 'pty' | 'shell'; sessionId: string } | null {
+  if (!focusedTerminalKey) return null;
+  const [type, ...rest] = focusedTerminalKey.split(':');
+  const sessionId = rest.join(':');
+  return { type: type as 'pty' | 'shell', sessionId };
+}
+
+// ─── Search Functions ───────────────────────────────────
+
+function getBufferText(terminal: Terminal): string {
+  const buf = terminal.buffer.active;
+  const lines: string[] = [];
+  for (let i = 0; i < buf.length; i++) {
+    const line = buf.getLine(i);
+    if (line) lines.push(line.translateToString(true));
+  }
+  return lines.join('\n');
+}
+
+function countMatches(text: string, term: string): number {
+  if (!term) return 0;
+  const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const matches = text.match(new RegExp(escaped, 'gi'));
+  return matches ? matches.length : 0;
+}
+
+export function terminalFindNext(type: 'pty' | 'shell', sessionId: string, term: string): { found: boolean; resultCount: number } {
+  const key = getTerminalKey(type, sessionId);
+  const entry = terminalCache.get(key);
+  if (!entry) return { found: false, resultCount: 0 };
+  const found = entry.searchAddon.findNext(term);
+  const resultCount = countMatches(getBufferText(entry.terminal), term);
+  return { found, resultCount };
+}
+
+export function terminalFindPrevious(type: 'pty' | 'shell', sessionId: string, term: string): { found: boolean; resultCount: number } {
+  const key = getTerminalKey(type, sessionId);
+  const entry = terminalCache.get(key);
+  if (!entry) return { found: false, resultCount: 0 };
+  const found = entry.searchAddon.findPrevious(term);
+  const resultCount = countMatches(getBufferText(entry.terminal), term);
+  return { found, resultCount };
+}
+
+export function terminalClearSearch(type: 'pty' | 'shell', sessionId: string): void {
+  const key = getTerminalKey(type, sessionId);
+  const entry = terminalCache.get(key);
+  if (entry) entry.searchAddon.clearDecorations();
 }
 
 const XTERM_THEME = {
@@ -114,6 +169,8 @@ export function TerminalView({ sessionId, type, visible = true }: TerminalViewPr
     terminal.loadAddon(new WebLinksAddon((_event, url) => {
       window.electronAPI.openExternal(url);
     }));
+    const searchAddon = new SearchAddon();
+    terminal.loadAddon(searchAddon);
 
     // Register data listener at creation time so background sessions keep receiving output
     const listenerMethod = type === 'pty' ? 'onPtyData' : 'onShellData';
@@ -123,7 +180,7 @@ export function TerminalView({ sessionId, type, visible = true }: TerminalViewPr
       }
     });
 
-    const entry: TerminalEntry = { terminal, fitAddon, mountedIn: null, opened: false, removeDataListener };
+    const entry: TerminalEntry = { terminal, fitAddon, searchAddon, mountedIn: null, opened: false, removeDataListener };
     terminalCache.set(key, entry);
     return entry;
   }, [type]);
@@ -186,11 +243,22 @@ export function TerminalView({ sessionId, type, visible = true }: TerminalViewPr
       }, 10);
     }
 
+    // Track terminal focus for search target resolution
+    const handleFocusIn = (): void => { focusedTerminalKey = key; };
+    const handleFocusOut = (): void => { if (focusedTerminalKey === key) focusedTerminalKey = null; };
+    container.addEventListener('focusin', handleFocusIn);
+    container.addEventListener('focusout', handleFocusOut);
+
     // Shift+Enter should insert a newline, not submit.
     // Claude Code enables kitty keyboard protocol (CSI u), so send the CSI u
     // encoding for Shift+Enter. Return false for ALL event types (keydown,
     // keypress, keyup) to prevent xterm from also sending \r.
+    // Cmd+F is handled by the Electron menu accelerator — return false to
+    // prevent xterm from inserting the character.
     terminal.attachCustomKeyEventHandler((event: KeyboardEvent) => {
+      if (event.metaKey && !event.altKey && (event.key === 'f' || event.key === 'g')) {
+        return false;
+      }
       if (event.key === 'Enter' && event.shiftKey) {
         if (event.type === 'keydown') {
           const sid = sessionIdRef.current;
@@ -229,6 +297,8 @@ export function TerminalView({ sessionId, type, visible = true }: TerminalViewPr
       dataDisposable.dispose();
       cancelAnimationFrame(resizeRafId);
       resizeObserver.disconnect();
+      container.removeEventListener('focusin', handleFocusIn);
+      container.removeEventListener('focusout', handleFocusOut);
       // Detach terminal DOM from container (don't dispose -- keep it alive for reparenting)
       if (terminal.element && terminal.element.parentNode === container) {
         container.removeChild(terminal.element);

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -47,6 +47,9 @@ interface ElectronAPI {
   onMenuPrevSession: (callback: () => void) => () => void;
   onMenuNextSession: (callback: () => void) => () => void;
   onMenuCloseSession: (callback: () => void) => () => void;
+  onMenuFind: (callback: () => void) => () => void;
+  onMenuFindNext: (callback: () => void) => () => void;
+  onMenuFindPrevious: (callback: () => void) => () => void;
 }
 
 declare global {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -52,6 +52,9 @@ export const IpcChannels = {
   MENU_PREV_SESSION: 'menu:prev-session',
   MENU_NEXT_SESSION: 'menu:next-session',
   MENU_CLOSE_SESSION: 'menu:close-session',
+  MENU_FIND: 'menu:find',
+  MENU_FIND_NEXT: 'menu:find-next',
+  MENU_FIND_PREVIOUS: 'menu:find-previous',
 } as const;
 
 export type IpcChannel = (typeof IpcChannels)[keyof typeof IpcChannels];
@@ -126,4 +129,7 @@ export interface IpcPushMap {
   [IpcChannels.MENU_PREV_SESSION]: void;
   [IpcChannels.MENU_NEXT_SESSION]: void;
   [IpcChannels.MENU_CLOSE_SESSION]: void;
+  [IpcChannels.MENU_FIND]: void;
+  [IpcChannels.MENU_FIND_NEXT]: void;
+  [IpcChannels.MENU_FIND_PREVIOUS]: void;
 }


### PR DESCRIPTION
## Summary
- Add `Cmd+F` to open a search bar overlay within the active terminal (Claude Code or shell)
- Add `Cmd+G` / `Cmd+Shift+G` to navigate between search matches (also `Enter` / `Shift+Enter`)
- Search targets the focused terminal, or defaults to the active session's Claude Code terminal
- Uses `@xterm/addon-search` for find/select, with manual buffer scanning for result count display

Closes #4

## Test plan
- [ ] Press `Cmd+F` with a terminal focused — search bar appears with auto-focus
- [ ] Type a search term — matching text is selected, result count shown
- [ ] Press `Enter` or `Cmd+G` — jumps to next match
- [ ] Press `Shift+Enter` or `Cmd+Shift+G` — jumps to previous match
- [ ] Press `Escape` — search bar closes, decorations cleared
- [ ] Click on shell terminal, then `Cmd+F` — searches shell terminal
- [ ] Switch sessions — search bar closes
- [ ] Press `Cmd+F` twice — search bar re-focuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)