### PR TITLE
Simplify forge config with asar unpack pattern

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -5,7 +5,6 @@ import { AutoUnpackNativesPlugin } from "@electron-forge/plugin-auto-unpack-nati
 import { VitePlugin } from "@electron-forge/plugin-vite";
 import path from "path";
 import fs from "fs";
-import { execSync } from "child_process";
 
 function copyNativeModules(buildPath: string) {
   const modulesToCopy = ["node-pty"];
@@ -18,57 +17,12 @@ function copyNativeModules(buildPath: string) {
   }
 }
 
-/**
- * After packaging, extract spawn-helper from the asar into the unpacked
- * directory. AutoUnpackNativesPlugin only unpacks .node files, but node-pty
- * also needs the spawn-helper executable at runtime.
- */
-function extractSpawnHelper(
-  _config: ForgeConfig,
-  packageResult: { outputPaths: string[] },
-): void {
-  for (const outputPath of packageResult.outputPaths) {
-    // outputPath is e.g. out/Chorus-darwin-arm64, app bundle is inside it
-    const appBundle = fs.readdirSync(outputPath).find((f) => f.endsWith(".app"));
-    if (!appBundle) continue;
-    const resourcesDir = path.join(outputPath, appBundle, "Contents", "Resources");
-    const asarPath = path.join(resourcesDir, "app.asar");
-    const unpackedDir = path.join(resourcesDir, "app.asar.unpacked");
-
-    if (!fs.existsSync(asarPath)) continue;
-
-    // Paths inside the asar where spawn-helper lives
-    const spawnHelperPaths = [
-      "node_modules/node-pty/build/Release/spawn-helper",
-      "node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper",
-      "node_modules/node-pty/prebuilds/darwin-x64/spawn-helper",
-    ];
-
-    // Extract full asar to a temp dir, then copy spawn-helper files
-    const tmpDir = path.join(outputPath, "_asar_tmp");
-    try {
-      execSync(`npx asar extract "${asarPath}" "${tmpDir}"`, { stdio: "pipe" });
-
-      for (const relPath of spawnHelperPaths) {
-        const srcPath = path.join(tmpDir, relPath);
-        if (!fs.existsSync(srcPath)) continue;
-
-        const destPath = path.join(unpackedDir, relPath);
-        fs.mkdirSync(path.dirname(destPath), { recursive: true });
-        fs.copyFileSync(srcPath, destPath);
-        fs.chmodSync(destPath, 0o755);
-        console.log(`[postPackage] Extracted ${relPath}`);
-      }
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
-  }
-}
-
 const config: ForgeConfig = {
   packagerConfig: {
     name: "Chorus",
-    asar: true,
+    asar: {
+      unpack: "{**/*.node,**/spawn-helper}",
+    },
     icon: "./assets/icons/icon",
     osxSign: {},
     osxNotarize: {
@@ -93,15 +47,7 @@ const config: ForgeConfig = {
       },
     ],
   },
-  hooks: {
-    postPackage: async (_config, packageResult) => {
-      extractSpawnHelper(_config, packageResult);
-    },
-  },
-  makers: [
-    new MakerZIP({}, ["darwin"]),
-    new MakerDMG({ format: "ULFO" }),
-  ],
+  makers: [new MakerZIP({}, ["darwin"]), new MakerDMG({ format: "ULFO" })],
   plugins: [
     new AutoUnpackNativesPlugin({}),
     new VitePlugin({


### PR DESCRIPTION
## Summary
- Replace manual `extractSpawnHelper` post-package hook with asar's built-in `unpack` glob pattern (`{**/*.node,**/spawn-helper}`)
- Remove unused `execSync` import and `postPackage` hook
- Net removal of ~54 lines of workaround code

## Test plan
- [x] `npm run make` completes successfully with code signing and notarization
- [x] Built app launches and terminal sessions work correctly (node-pty spawn-helper is properly unpacked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)