### PR TITLE
Add configurable terminal font family with Preferences dialog

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -324,6 +324,14 @@ function createMenu(): void {
           },
         },
         { type: "separator" },
+        {
+          label: "Preferences\u2026",
+          accelerator: "CmdOrCtrl+,",
+          click: () => {
+            mainWindow?.webContents.send(IpcChannels.MENU_PREFERENCES);
+          },
+        },
+        { type: "separator" },
         { role: "hide" },
         { role: "hideOthers" },
         { role: "unhide" },

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -94,4 +94,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('menu:find-previous', listener);
     return () => ipcRenderer.removeListener('menu:find-previous', listener);
   },
+  onMenuPreferences: (callback: () => void) => {
+    const listener = () => callback();
+    ipcRenderer.on('menu:preferences', listener);
+    return () => ipcRenderer.removeListener('menu:preferences', listener);
+  },
 });

--- a/src/main/session-store.ts
+++ b/src/main/session-store.ts
@@ -6,6 +6,7 @@ import type {
   PersistedSession,
   AppState,
   NewSessionDefaults,
+  TerminalSettings,
   ToolkitCommand,
   WindowBounds,
   PanelSizes,
@@ -36,11 +37,16 @@ const DEFAULT_NEW_SESSION_DEFAULTS: NewSessionDefaults = {
   notifyOnIdle: false,
 };
 
+const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
+  fontFamily: "'JetBrains Mono', 'IBM Plex Mono', 'SF Mono', 'Fira Code', monospace",
+};
+
 const DEFAULT_APP_STATE: AppState = {
   windowBounds: DEFAULT_WINDOW_BOUNDS,
   panelSizes: DEFAULT_PANEL_SIZES,
   lastActiveSessionId: null,
   newSessionDefaults: DEFAULT_NEW_SESSION_DEFAULTS,
+  terminalSettings: DEFAULT_TERMINAL_SETTINGS,
 };
 
 function ensureDir(): void {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -5,9 +5,10 @@ import { StatusBar } from './components/StatusBar';
 import { ShellPanel } from './components/ShellPanel';
 import { SessionList } from './components/SessionList';
 import { ToolkitPanel } from './components/ToolkitPanel';
-import { TerminalView, disposeTerminal, focusTerminal, getFocusedTerminalInfo } from './components/TerminalView';
+import { TerminalView, disposeTerminal, focusTerminal, getFocusedTerminalInfo, setAllTerminalsFontFamily } from './components/TerminalView';
 import { SearchBar } from './components/SearchBar';
 import { NewSessionDialog } from './components/NewSessionDialog';
+import { PreferencesDialog } from './components/PreferencesDialog';
 
 const DEFAULT_SIDEBAR_WIDTH = 320;
 const DEFAULT_SHELL_HEIGHT = 200;
@@ -20,6 +21,8 @@ export function App(): React.ReactElement {
   const [toolkitCommands, setToolkitCommands] = useState<ToolkitCommand[]>([]);
   const [shellCollapsed, setShellCollapsed] = useState(false);
   const [showNewSession, setShowNewSession] = useState(false);
+  const [showPreferences, setShowPreferences] = useState(false);
+  const [terminalFontFamily, setTerminalFontFamily] = useState("'JetBrains Mono', 'IBM Plex Mono', 'SF Mono', 'Fira Code', monospace");
   const [endSessionConfirm, setEndSessionConfirm] = useState<string | null>(null);
   const [search, setSearch] = useState<{ type: 'pty' | 'shell'; sessionId: string; key: number } | null>(null);
   const searchKeyRef = useRef(0);
@@ -45,6 +48,9 @@ export function App(): React.ReactElement {
       }
       if (state.lastActiveSessionId) {
         setActiveSessionId(state.lastActiveSessionId);
+      }
+      if (state.terminalSettings?.fontFamily) {
+        setTerminalFontFamily(state.terminalSettings.fontFamily);
       }
     });
 
@@ -126,6 +132,9 @@ export function App(): React.ReactElement {
         } else {
           setSearch({ type: 'pty', sessionId: currentId, key: k });
         }
+      }),
+      window.electronAPI.onMenuPreferences(() => {
+        setShowPreferences(true);
       }),
     ];
     return () => cleanups.forEach((c) => c());
@@ -275,6 +284,16 @@ export function App(): React.ReactElement {
     []
   );
 
+  const handleSavePreferences = useCallback(
+    (settings: { fontFamily: string }) => {
+      setTerminalFontFamily(settings.fontFamily);
+      setAllTerminalsFontFamily(settings.fontFamily);
+      window.electronAPI.appSaveState({ terminalSettings: { fontFamily: settings.fontFamily } });
+      setShowPreferences(false);
+    },
+    []
+  );
+
   const handleShellToggle = useCallback(() => {
     setShellCollapsed((prev) => {
       const next = !prev;
@@ -371,12 +390,12 @@ export function App(): React.ReactElement {
           >
             {/* Claude Code terminal */}
             <div style={{ width: '100%', height: '100%', background: 'var(--bg-terminal)' }}>
-              <TerminalView sessionId={activeSessionId} type="pty" />
+              <TerminalView sessionId={activeSessionId} type="pty" fontFamily={terminalFontFamily} />
             </div>
 
             {/* Shell terminal (collapsible) */}
             <ShellPanel collapsed={shellCollapsed} onToggle={handleShellToggle}>
-              <TerminalView sessionId={activeSessionId} type="shell" visible={!shellCollapsed} />
+              <TerminalView sessionId={activeSessionId} type="shell" visible={!shellCollapsed} fontFamily={terminalFontFamily} />
             </ShellPanel>
           </SplitPane>
         </div>
@@ -418,6 +437,14 @@ export function App(): React.ReactElement {
         open={showNewSession}
         onClose={() => setShowNewSession(false)}
         onSubmit={handleNewSession}
+      />
+
+      {/* Preferences dialog */}
+      <PreferencesDialog
+        open={showPreferences}
+        fontFamily={terminalFontFamily}
+        onClose={() => setShowPreferences(false)}
+        onSave={handleSavePreferences}
       />
 
       {/* End session confirmation dialog */}

--- a/src/renderer/components/PreferencesDialog.tsx
+++ b/src/renderer/components/PreferencesDialog.tsx
@@ -1,0 +1,214 @@
+import React, { useState, useEffect, useRef } from 'react';
+
+interface PreferencesDialogProps {
+  open: boolean;
+  fontFamily: string;
+  onClose: () => void;
+  onSave: (settings: { fontFamily: string }) => void;
+}
+
+export function PreferencesDialog({ open, fontFamily, onClose, onSave }: PreferencesDialogProps): React.ReactElement | null {
+  const [font, setFont] = useState(fontFamily);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setFont(fontFamily);
+    setTimeout(() => inputRef.current?.focus(), 50);
+  }, [open, fontFamily]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      if (e.key === 'Tab' && dialogRef.current) {
+        const focusable = dialogRef.current.querySelectorAll<HTMLElement>(
+          'input, button, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, onClose]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!font.trim()) return;
+    onSave({ fontFamily: font.trim() });
+  };
+
+  if (!open) return null;
+
+  return (
+    <div style={overlayStyle} onClick={onClose}>
+      <div ref={dialogRef} style={dialogStyle} onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-label="Preferences">
+        <div style={titleStyle}>Preferences</div>
+        <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <div style={fieldStyle}>
+            <label style={labelStyle}>Terminal Font Family</label>
+            <input
+              ref={inputRef}
+              style={inputStyle}
+              value={font}
+              onChange={(e) => setFont(e.target.value)}
+              placeholder="'JetBrains Mono', 'Fira Code', monospace"
+            />
+            <span style={hintStyle}>
+              Comma-separated list of fonts. Fonts are tried in order; the first available one is used.
+            </span>
+          </div>
+
+          {/* Preview */}
+          <div style={previewContainerStyle}>
+            <span style={previewLabelStyle}>Preview</span>
+            <div style={{ ...previewTextStyle, fontFamily: font || undefined }}>
+              AaBbCc 0123 {'{ }'} =&gt; !=
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 4 }}>
+            <button type="button" style={cancelButtonStyle} onClick={onClose}>
+              Cancel
+            </button>
+            <button
+              type="submit"
+              style={{
+                ...submitButtonStyle,
+                opacity: font.trim() ? 1 : 0.4,
+              }}
+              disabled={!font.trim()}
+            >
+              Save
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+const overlayStyle: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0, 0, 0, 0.6)',
+  backdropFilter: 'blur(4px)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 2000,
+  animation: 'fadeIn 150ms ease',
+};
+
+const dialogStyle: React.CSSProperties = {
+  background: 'var(--bg-elevated)',
+  border: '1px solid var(--border-default)',
+  borderRadius: 'var(--radius-lg)',
+  boxShadow: 'var(--shadow-lg)',
+  padding: 24,
+  width: 420,
+  maxWidth: '90vw',
+  animation: 'slideUp 200ms ease',
+};
+
+const titleStyle: React.CSSProperties = {
+  fontSize: 14,
+  fontWeight: 600,
+  color: 'var(--text-primary)',
+  marginBottom: 18,
+  letterSpacing: '0.02em',
+};
+
+const fieldStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 10,
+  fontWeight: 500,
+  color: 'var(--text-secondary)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+};
+
+const inputStyle: React.CSSProperties = {
+  background: 'var(--bg-surface)',
+  border: '1px solid var(--border-default)',
+  borderRadius: 'var(--radius-md)',
+  padding: '7px 10px',
+  fontSize: 12,
+  color: 'var(--text-primary)',
+  fontFamily: 'var(--font-mono)',
+  transition: 'border-color var(--transition-fast)',
+};
+
+const hintStyle: React.CSSProperties = {
+  fontSize: 10,
+  color: 'var(--text-dimmed)',
+  lineHeight: 1.4,
+  marginTop: 2,
+};
+
+const previewContainerStyle: React.CSSProperties = {
+  background: 'var(--bg-terminal)',
+  border: '1px solid var(--border-default)',
+  borderRadius: 'var(--radius-md)',
+  padding: '10px 12px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+};
+
+const previewLabelStyle: React.CSSProperties = {
+  fontSize: 9,
+  fontWeight: 500,
+  color: 'var(--text-dimmed)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+};
+
+const previewTextStyle: React.CSSProperties = {
+  fontSize: 13,
+  color: 'var(--text-primary)',
+  lineHeight: 1.4,
+};
+
+const cancelButtonStyle: React.CSSProperties = {
+  padding: '7px 16px',
+  borderRadius: 'var(--radius-md)',
+  fontSize: 11,
+  color: 'var(--text-secondary)',
+  background: 'var(--bg-surface)',
+  border: '1px solid var(--border-default)',
+  cursor: 'pointer',
+  fontFamily: 'var(--font-ui)',
+  transition: 'all var(--transition-fast)',
+};
+
+const submitButtonStyle: React.CSSProperties = {
+  padding: '7px 20px',
+  borderRadius: 'var(--radius-md)',
+  fontSize: 11,
+  fontWeight: 600,
+  color: '#fff',
+  background: 'var(--accent-blue)',
+  border: 'none',
+  cursor: 'pointer',
+  fontFamily: 'var(--font-ui)',
+  transition: 'all var(--transition-fast)',
+};

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -5,10 +5,13 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import { SearchAddon } from '@xterm/addon-search';
 import '@xterm/xterm/css/xterm.css';
 
+const DEFAULT_FONT_FAMILY = "'JetBrains Mono', 'IBM Plex Mono', 'SF Mono', 'Fira Code', monospace";
+
 interface TerminalViewProps {
   sessionId: string | null;
   type: 'pty' | 'shell';
   visible?: boolean;
+  fontFamily?: string;
 }
 
 interface TerminalEntry {
@@ -99,6 +102,14 @@ export function terminalClearSearch(type: 'pty' | 'shell', sessionId: string): v
   if (entry) entry.searchAddon.clearDecorations();
 }
 
+/** Update font family on all cached terminal instances. */
+export function setAllTerminalsFontFamily(fontFamily: string): void {
+  for (const entry of terminalCache.values()) {
+    entry.terminal.options.fontFamily = fontFamily;
+    try { entry.fitAddon.fit(); } catch { /* not mounted */ }
+  }
+}
+
 const XTERM_THEME = {
   background: '#0a0a14',
   foreground: '#d8d8e8',
@@ -141,13 +152,14 @@ function safeFitAndResize(
   }
 }
 
-export function TerminalView({ sessionId, type, visible = true }: TerminalViewProps): React.ReactElement {
+export function TerminalView({ sessionId, type, visible = true, fontFamily }: TerminalViewProps): React.ReactElement {
   const containerRef = useRef<HTMLDivElement>(null);
   const sessionIdRef = useRef(sessionId);
   sessionIdRef.current = sessionId;
 
   const resizeMethod = type === 'pty' ? 'ptyResize' : 'shellResize' as const;
   const writeMethod = type === 'pty' ? 'ptyWrite' : 'shellWrite' as const;
+  const resolvedFont = fontFamily || DEFAULT_FONT_FAMILY;
 
   const getOrCreateTerminal = useCallback((key: string, sid: string): TerminalEntry => {
     const existing = terminalCache.get(key);
@@ -156,7 +168,7 @@ export function TerminalView({ sessionId, type, visible = true }: TerminalViewPr
     const terminal = new Terminal({
       cursorBlink: true,
       cursorStyle: 'bar',
-      fontFamily: "'JetBrains Mono', 'IBM Plex Mono', 'SF Mono', 'Fira Code', monospace",
+      fontFamily: resolvedFont,
       fontSize: 13,
       lineHeight: 1,
       theme: XTERM_THEME,
@@ -183,7 +195,7 @@ export function TerminalView({ sessionId, type, visible = true }: TerminalViewPr
     const entry: TerminalEntry = { terminal, fitAddon, searchAddon, mountedIn: null, opened: false, removeDataListener };
     terminalCache.set(key, entry);
     return entry;
-  }, [type]);
+  }, [type, resolvedFont]);
 
   // Attach terminal to DOM and handle I/O
   useEffect(() => {

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -50,6 +50,7 @@ interface ElectronAPI {
   onMenuFind: (callback: () => void) => () => void;
   onMenuFindNext: (callback: () => void) => () => void;
   onMenuFindPrevious: (callback: () => void) => () => void;
+  onMenuPreferences: (callback: () => void) => () => void;
 }
 
 declare global {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -55,6 +55,7 @@ export const IpcChannels = {
   MENU_FIND: 'menu:find',
   MENU_FIND_NEXT: 'menu:find-next',
   MENU_FIND_PREVIOUS: 'menu:find-previous',
+  MENU_PREFERENCES: 'menu:preferences',
 } as const;
 
 export type IpcChannel = (typeof IpcChannels)[keyof typeof IpcChannels];
@@ -132,4 +133,5 @@ export interface IpcPushMap {
   [IpcChannels.MENU_FIND]: void;
   [IpcChannels.MENU_FIND_NEXT]: void;
   [IpcChannels.MENU_FIND_PREVIOUS]: void;
+  [IpcChannels.MENU_PREFERENCES]: void;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -69,6 +69,12 @@ export interface ToolkitCommand {
   icon?: string;
 }
 
+// ─── Terminal Settings ───────────────────────────────────
+
+export interface TerminalSettings {
+  fontFamily: string;
+}
+
 // ─── App State ───────────────────────────────────────────
 
 export interface AppState {
@@ -76,6 +82,7 @@ export interface AppState {
   panelSizes: PanelSizes;
   lastActiveSessionId: string | null;
   newSessionDefaults: NewSessionDefaults;
+  terminalSettings: TerminalSettings;
 }
 
 export interface WindowBounds {


### PR DESCRIPTION
## Summary

Closes #9

- Add Preferences dialog (`Cmd+,`) with terminal font family setting
- Support comma-separated font fallback chains (e.g. `JetBrains Mono, Fira Code, monospace`)
- Live preview in the dialog shows the selected font
- Changes apply immediately to all open terminal sessions
- Settings persist to `~/.chorus/state.json` across app restarts

## Test plan

- [x] Open Preferences via `Cmd+,` or app menu
- [x] Change font family and verify live preview updates
- [x] Click Save and verify all terminals update immediately
- [x] Restart app and verify the font setting persists
- [x] Enter an invalid font name and verify graceful fallback to next available font
- [x] Verify Escape key and Cancel button close the dialog without saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)