### PR TITLE
Use @xterm/addon-search decorations for match counting

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -24,7 +24,8 @@ export function App(): React.ReactElement {
   const [showPreferences, setShowPreferences] = useState(false);
   const [terminalFontFamily, setTerminalFontFamily] = useState("'JetBrains Mono', 'IBM Plex Mono', 'SF Mono', 'Fira Code', monospace");
   const [endSessionConfirm, setEndSessionConfirm] = useState<string | null>(null);
-  const [search, setSearch] = useState<{ type: 'pty' | 'shell'; sessionId: string; key: number } | null>(null);
+  const [ptySearch, setPtySearch] = useState<{ sessionId: string; key: number } | null>(null);
+  const [shellSearch, setShellSearch] = useState<{ sessionId: string; key: number } | null>(null);
   const searchKeyRef = useRef(0);
 
   // Panel sizes
@@ -127,10 +128,10 @@ export function App(): React.ReactElement {
         if (!currentId) return;
         const k = ++searchKeyRef.current;
         const focused = getFocusedTerminalInfo();
-        if (focused && focused.sessionId === currentId) {
-          setSearch({ type: focused.type, sessionId: focused.sessionId, key: k });
+        if (focused && focused.sessionId === currentId && focused.type === 'shell') {
+          setShellSearch({ sessionId: focused.sessionId, key: k });
         } else {
-          setSearch({ type: 'pty', sessionId: currentId, key: k });
+          setPtySearch({ sessionId: currentId, key: k });
         }
       }),
       window.electronAPI.onMenuPreferences(() => {
@@ -162,7 +163,8 @@ export function App(): React.ReactElement {
   const handleSelectSession = useCallback(
     (id: string) => {
       setActiveSessionId(id);
-      setSearch(null);
+      setPtySearch(null);
+      setShellSearch(null);
       window.electronAPI.sessionSwitch(id);
       window.electronAPI.appSaveState({ lastActiveSessionId: id });
     },
@@ -368,15 +370,6 @@ export function App(): React.ReactElement {
         <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden', position: 'relative' }}>
           <StatusBar session={activeSession} />
 
-          {search && (
-            <SearchBar
-              key={search.key}
-              type={search.type}
-              sessionId={search.sessionId}
-              onClose={() => setSearch(null)}
-            />
-          )}
-
           <SplitPane
             direction="vertical"
             initialSize={shellCollapsed ? 28 : shellHeight}
@@ -389,13 +382,31 @@ export function App(): React.ReactElement {
             collapsedSize={28}
           >
             {/* Claude Code terminal */}
-            <div style={{ width: '100%', height: '100%', background: 'var(--bg-terminal)' }}>
+            <div style={{ width: '100%', height: '100%', background: 'var(--bg-terminal)', position: 'relative' }}>
+              {ptySearch && (
+                <SearchBar
+                  key={ptySearch.key}
+                  type="pty"
+                  sessionId={ptySearch.sessionId}
+                  onClose={() => setPtySearch(null)}
+                />
+              )}
               <TerminalView sessionId={activeSessionId} type="pty" fontFamily={terminalFontFamily} />
             </div>
 
             {/* Shell terminal (collapsible) */}
             <ShellPanel collapsed={shellCollapsed} onToggle={handleShellToggle}>
-              <TerminalView sessionId={activeSessionId} type="shell" visible={!shellCollapsed} fontFamily={terminalFontFamily} />
+              <div style={{ width: '100%', height: '100%', position: 'relative' }}>
+                {shellSearch && (
+                  <SearchBar
+                    key={shellSearch.key}
+                    type="shell"
+                    sessionId={shellSearch.sessionId}
+                    onClose={() => setShellSearch(null)}
+                  />
+                )}
+                <TerminalView sessionId={activeSessionId} type="shell" visible={!shellCollapsed} fontFamily={terminalFontFamily} />
+              </div>
             </ShellPanel>
           </SplitPane>
         </div>

--- a/src/renderer/components/SearchBar.tsx
+++ b/src/renderer/components/SearchBar.tsx
@@ -3,7 +3,10 @@ import {
   terminalFindNext,
   terminalFindPrevious,
   terminalClearSearch,
+  getFocusedTerminalInfo,
 } from './TerminalView';
+
+let activeSearchType: 'pty' | 'shell' | null = null;
 
 interface SearchBarProps {
   type: 'pty' | 'shell';
@@ -18,9 +21,11 @@ export function SearchBar({ type, sessionId, onClose }: SearchBarProps): React.R
   const [resultCount, setResultCount] = useState(0);
 
   useEffect(() => {
+    activeSearchType = type;
     inputRef.current?.focus();
     inputRef.current?.select();
-  }, []);
+    return () => { if (activeSearchType === type) activeSearchType = null; };
+  }, [type]);
 
   useEffect(() => {
     if (query) {
@@ -54,12 +59,18 @@ export function SearchBar({ type, sessionId, onClose }: SearchBarProps): React.R
   }, [type, sessionId]);
 
   useEffect(() => {
+    const isOwner = () => {
+      const focused = getFocusedTerminalInfo();
+      return focused ? focused.type === type : activeSearchType === type;
+    };
+    const guardedNext = () => { if (isOwner()) handleNext(); };
+    const guardedPrev = () => { if (isOwner()) handlePrev(); };
     const cleanups = [
-      window.electronAPI.onMenuFindNext(handleNext),
-      window.electronAPI.onMenuFindPrevious(handlePrev),
+      window.electronAPI.onMenuFindNext(guardedNext),
+      window.electronAPI.onMenuFindPrevious(guardedPrev),
     ];
     return () => cleanups.forEach((c) => c());
-  }, [handleNext, handlePrev]);
+  }, [handleNext, handlePrev, type]);
 
   const handleClose = useCallback(() => {
     terminalClearSearch(type, sessionId);
@@ -93,6 +104,7 @@ export function SearchBar({ type, sessionId, onClose }: SearchBarProps): React.R
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => { activeSearchType = type; }}
           onKeyDown={handleKeyDown}
           placeholder="Search..."
           style={inputStyle}
@@ -122,7 +134,7 @@ export function SearchBar({ type, sessionId, onClose }: SearchBarProps): React.R
 
 const containerStyle: React.CSSProperties = {
   position: 'absolute',
-  top: 'calc(var(--status-bar-height) + 8px)',
+  top: 8,
   right: 16,
   zIndex: 100,
   animation: 'slideDown 120ms ease',

--- a/src/renderer/components/SearchBar.tsx
+++ b/src/renderer/components/SearchBar.tsx
@@ -14,6 +14,7 @@ interface SearchBarProps {
 export function SearchBar({ type, sessionId, onClose }: SearchBarProps): React.ReactElement {
   const inputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState('');
+  const [resultIndex, setResultIndex] = useState(-1);
   const [resultCount, setResultCount] = useState(0);
 
   useEffect(() => {
@@ -23,10 +24,12 @@ export function SearchBar({ type, sessionId, onClose }: SearchBarProps): React.R
 
   useEffect(() => {
     if (query) {
-      const { resultCount: count } = terminalFindNext(type, sessionId, query);
-      setResultCount(count);
+      const result = terminalFindNext(type, sessionId, query);
+      setResultIndex(result.resultIndex);
+      setResultCount(result.resultCount);
     } else {
       terminalClearSearch(type, sessionId);
+      setResultIndex(-1);
       setResultCount(0);
     }
   }, [query, type, sessionId]);
@@ -36,15 +39,17 @@ export function SearchBar({ type, sessionId, onClose }: SearchBarProps): React.R
 
   const handleNext = useCallback(() => {
     if (queryRef.current) {
-      const { resultCount: count } = terminalFindNext(type, sessionId, queryRef.current);
-      setResultCount(count);
+      const result = terminalFindNext(type, sessionId, queryRef.current);
+      setResultIndex(result.resultIndex);
+      setResultCount(result.resultCount);
     }
   }, [type, sessionId]);
 
   const handlePrev = useCallback(() => {
     if (queryRef.current) {
-      const { resultCount: count } = terminalFindPrevious(type, sessionId, queryRef.current);
-      setResultCount(count);
+      const result = terminalFindPrevious(type, sessionId, queryRef.current);
+      setResultIndex(result.resultIndex);
+      setResultCount(result.resultCount);
     }
   }, [type, sessionId]);
 
@@ -76,7 +81,7 @@ export function SearchBar({ type, sessionId, onClose }: SearchBarProps): React.R
 
   const resultText = query
     ? resultCount > 0
-      ? `${resultCount} results`
+      ? `${resultIndex + 1} of ${resultCount}`
       : 'No results'
     : '';
 

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -14,10 +14,16 @@ interface TerminalViewProps {
   fontFamily?: string;
 }
 
+interface SearchResult {
+  resultIndex: number;
+  resultCount: number;
+}
+
 interface TerminalEntry {
   terminal: Terminal;
   fitAddon: FitAddon;
   searchAddon: SearchAddon;
+  searchResult: SearchResult;
   mountedIn: HTMLElement | null;
   opened: boolean;
   removeDataListener: (() => void) | null;
@@ -61,39 +67,29 @@ export function getFocusedTerminalInfo(): { type: 'pty' | 'shell'; sessionId: st
 
 // ─── Search Functions ───────────────────────────────────
 
-function getBufferText(terminal: Terminal): string {
-  const buf = terminal.buffer.active;
-  const lines: string[] = [];
-  for (let i = 0; i < buf.length; i++) {
-    const line = buf.getLine(i);
-    if (line) lines.push(line.translateToString(true));
-  }
-  return lines.join('\n');
-}
+const SEARCH_DECORATIONS = {
+  matchBackground: '#3c4d6e',
+  matchBorder: 'transparent',
+  matchOverviewRuler: '#5a7fbf',
+  activeMatchBackground: '#5a9bcf',
+  activeMatchBorder: '#7ec4ef',
+  activeMatchColorOverviewRuler: '#7ec4ef',
+};
 
-function countMatches(text: string, term: string): number {
-  if (!term) return 0;
-  const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const matches = text.match(new RegExp(escaped, 'gi'));
-  return matches ? matches.length : 0;
-}
-
-export function terminalFindNext(type: 'pty' | 'shell', sessionId: string, term: string): { found: boolean; resultCount: number } {
+export function terminalFindNext(type: 'pty' | 'shell', sessionId: string, term: string): SearchResult {
   const key = getTerminalKey(type, sessionId);
   const entry = terminalCache.get(key);
-  if (!entry) return { found: false, resultCount: 0 };
-  const found = entry.searchAddon.findNext(term);
-  const resultCount = countMatches(getBufferText(entry.terminal), term);
-  return { found, resultCount };
+  if (!entry) return { resultIndex: -1, resultCount: 0 };
+  entry.searchAddon.findNext(term, { decorations: SEARCH_DECORATIONS });
+  return { ...entry.searchResult };
 }
 
-export function terminalFindPrevious(type: 'pty' | 'shell', sessionId: string, term: string): { found: boolean; resultCount: number } {
+export function terminalFindPrevious(type: 'pty' | 'shell', sessionId: string, term: string): SearchResult {
   const key = getTerminalKey(type, sessionId);
   const entry = terminalCache.get(key);
-  if (!entry) return { found: false, resultCount: 0 };
-  const found = entry.searchAddon.findPrevious(term);
-  const resultCount = countMatches(getBufferText(entry.terminal), term);
-  return { found, resultCount };
+  if (!entry) return { resultIndex: -1, resultCount: 0 };
+  entry.searchAddon.findPrevious(term, { decorations: SEARCH_DECORATIONS });
+  return { ...entry.searchResult };
 }
 
 export function terminalClearSearch(type: 'pty' | 'shell', sessionId: string): void {
@@ -166,6 +162,7 @@ export function TerminalView({ sessionId, type, visible = true, fontFamily }: Te
     if (existing) return existing;
 
     const terminal = new Terminal({
+      allowProposedApi: true,
       cursorBlink: true,
       cursorStyle: 'bar',
       fontFamily: resolvedFont,
@@ -184,6 +181,12 @@ export function TerminalView({ sessionId, type, visible = true, fontFamily }: Te
     const searchAddon = new SearchAddon();
     terminal.loadAddon(searchAddon);
 
+    const searchResult: SearchResult = { resultIndex: -1, resultCount: 0 };
+    searchAddon.onDidChangeResults((e) => {
+      searchResult.resultIndex = e.resultIndex;
+      searchResult.resultCount = e.resultCount;
+    });
+
     // Register data listener at creation time so background sessions keep receiving output
     const listenerMethod = type === 'pty' ? 'onPtyData' : 'onShellData';
     const removeDataListener = window.electronAPI[listenerMethod]((payload) => {
@@ -192,7 +195,7 @@ export function TerminalView({ sessionId, type, visible = true, fontFamily }: Te
       }
     });
 
-    const entry: TerminalEntry = { terminal, fitAddon, searchAddon, mountedIn: null, opened: false, removeDataListener };
+    const entry: TerminalEntry = { terminal, fitAddon, searchAddon, searchResult, mountedIn: null, opened: false, removeDataListener };
     terminalCache.set(key, entry);
     return entry;
   }, [type, resolvedFont]);


### PR DESCRIPTION
## Summary

- Replace manual buffer text parsing (`getBufferText` + `countMatches`) with the SearchAddon's native `onDidChangeResults` event
- Pass `decorations` option to `findNext`/`findPrevious` for built-in match highlighting
- Enable `allowProposedApi` on Terminal (required for xterm decoration API)
- Show "X of Y" in search bar instead of "N results"
- Give each terminal (pty / shell) its own independent search bar, positioned within its pane
- Route Cmd+G / Cmd+Shift+G only to the focused terminal's search bar (using `activeSearchType` fallback when the search input has focus)

Closes #11

## Test plan

- [x] Open a terminal session with some output
- [x] Press Cmd+F to open search bar — verify it appears in the pty terminal area
- [x] Type a search term — verify matches are highlighted and "X of Y" counter is shown
- [x] Press Enter / Shift+Enter — verify the counter updates as you navigate between matches
- [x] Click into the shell terminal, press Cmd+F — verify a separate search bar appears in the shell pane
- [x] Press Cmd+G — verify only the focused terminal's search advances
- [x] Press Escape — verify decorations are cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)
