### PR TITLE
Refine UI/UX across session cards, status bar, shell header, and dividers

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -373,6 +373,10 @@ export function App(): React.ReactElement {
           background: var(--bg-hover);
           outline: none;
         }
+        /* Divider hover highlight */
+        [data-divider] {
+          background: rgba(var(--tint-rgb), 0.14) !important;
+        }
       `}</style>
 
       {/* Main layout: left/right split */}

--- a/src/renderer/components/SessionList.tsx
+++ b/src/renderer/components/SessionList.tsx
@@ -29,6 +29,7 @@ interface SessionListProps {
 
 const statusColors: Record<string, string> = {
   idle: 'var(--status-idle)',
+  waiting: 'var(--status-idle)',
   thinking: 'var(--status-thinking)',
   generating: 'var(--status-generating)',
   creating: 'var(--status-creating)',
@@ -307,6 +308,7 @@ function SessionCard({ session, isActive, isEditing, onClick, onContextMenu, onR
   const [editValue, setEditValue] = useState(session.name);
   const inputRef = useRef<HTMLInputElement>(null);
   const statusColor = statusColors[session.status] ?? 'var(--text-dimmed)';
+  const isPulsing = session.status === 'thinking' || session.status === 'generating' || session.status === 'waiting';
 
   // Focus input when entering edit mode
   useEffect(() => {
@@ -336,7 +338,6 @@ function SessionCard({ session, isActive, isEditing, onClick, onContextMenu, onR
         ...cardStyle,
         background: isActive ? 'var(--bg-active)' : hovered ? 'var(--bg-hover)' : 'transparent',
         borderLeft: isActive ? '2px solid var(--accent-primary)' : '2px solid transparent',
-        boxShadow: isActive ? 'inset 0 0 0 1px rgba(var(--accent-rgb), 0.08)' : undefined,
       }}
       onClick={isEditing ? undefined : onClick}
       onContextMenu={(e) => {
@@ -346,7 +347,7 @@ function SessionCard({ session, isActive, isEditing, onClick, onContextMenu, onR
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
-      {/* Top row: name + status */}
+      {/* Row 1: name + bell + status */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
         {isEditing ? (
           <input
@@ -381,7 +382,7 @@ function SessionCard({ session, isActive, isEditing, onClick, onContextMenu, onR
               />
             ) : !session.hasUserInput ? (
               <span
-                title="No user input yet"
+                title="No user input yet — session won't be persisted"
                 style={{
                   width: 6,
                   height: 6,
@@ -394,11 +395,11 @@ function SessionCard({ session, isActive, isEditing, onClick, onContextMenu, onR
             <span style={{
               fontWeight: session.unread ? 600 : 500,
               fontSize: 12,
-              color: session.unread ? 'var(--text-primary)' : 'var(--text-primary)',
+              color: session.unread ? 'var(--text-accent)' : 'var(--text-primary)',
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
-              transition: 'color var(--transition-fast), font-weight var(--transition-fast)',
+              transition: 'color var(--transition-fast)',
             }}>
               {session.name}
             </span>
@@ -429,14 +430,8 @@ function SessionCard({ session, isActive, isEditing, onClick, onContextMenu, onR
               borderRadius: '50%',
               backgroundColor: statusColor,
               display: 'inline-block',
-              animation:
-                session.status === 'thinking' || session.status === 'generating'
-                  ? 'statusPulse 1.5s ease-in-out infinite'
-                  : undefined,
-              boxShadow:
-                session.status === 'thinking' || session.status === 'generating'
-                  ? `0 0 4px ${statusColor}`
-                  : undefined,
+              animation: isPulsing ? 'statusPulse 1.5s ease-in-out infinite' : undefined,
+              boxShadow: isPulsing ? `0 0 4px ${statusColor}` : undefined,
             }}
           />
           <span style={{ fontSize: 10, color: statusColor, textTransform: 'capitalize' }}>
@@ -445,7 +440,7 @@ function SessionCard({ session, isActive, isEditing, onClick, onContextMenu, onR
         </div>
       </div>
 
-      {/* Working dir + worktree */}
+      {/* Row 2: cwd + worktree */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 2 }}>
         <div style={{ fontSize: 10, color: 'var(--text-dimmed)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1, minWidth: 0 }}>
           {shortenPath(session.cwd)}
@@ -457,7 +452,7 @@ function SessionCard({ session, isActive, isEditing, onClick, onContextMenu, onR
         )}
       </div>
 
-      {/* Bottom row: model, branch, context */}
+      {/* Row 3: model, branch, context */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 4, flexWrap: 'wrap' }}>
         {session.model && (
           <span style={cardTagStyle}>{session.model}</span>
@@ -559,8 +554,7 @@ const headerBarStyle: React.CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  height: 'var(--status-bar-height)',
-  padding: '0 12px 0 16px',
+  padding: '8px 14px',
   borderBottom: '1px solid var(--border-subtle)',
   flexShrink: 0,
 };
@@ -571,15 +565,15 @@ const newSessionButtonStyle: React.CSSProperties = {
   height: 22,
   borderRadius: 'var(--radius-sm)',
   border: 'none',
-  background: 'var(--bg-hover)',
-  color: 'var(--text-secondary)',
-  fontSize: 15,
+  background: 'transparent',
+  color: 'var(--text-dimmed)',
+  fontSize: 16,
   lineHeight: 1,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   cursor: 'pointer',
-  transition: 'all var(--transition-fast)',
+  transition: 'color var(--transition-fast)',
 };
 
 const headerTitleStyle: React.CSSProperties = {

--- a/src/renderer/components/ShellPanel.tsx
+++ b/src/renderer/components/ShellPanel.tsx
@@ -10,21 +10,22 @@ export function ShellPanel({ collapsed, onToggle, children }: ShellPanelProps): 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
       <div style={headerStyle} onClick={onToggle}>
-        <span
-          style={{
-            display: 'inline-block',
-            transition: 'transform var(--transition-fast)',
-            transform: collapsed ? 'rotate(-90deg)' : 'rotate(0deg)',
-            fontSize: 9,
-            color: 'var(--text-dimmed)',
-            marginRight: 6,
-          }}
-        >
-          ▼
-        </span>
         <span style={{ color: 'var(--text-dimmed)', fontWeight: 600, fontSize: 11, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
           Shell
         </span>
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          fill="none"
+          style={{
+            marginLeft: 5,
+            transition: 'transform var(--transition-fast)',
+            transform: collapsed ? 'rotate(-90deg)' : 'rotate(0deg)',
+          }}
+        >
+          <path d="M2.5 3.5L5 6.5L7.5 3.5" stroke="var(--text-dimmed)" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
       </div>
       {!collapsed && (
         <div style={{ flex: 1, overflow: 'hidden', background: 'var(--bg-terminal)' }}>
@@ -39,9 +40,9 @@ const headerStyle: React.CSSProperties = {
   height: 'var(--shell-collapsed-height)',
   display: 'flex',
   alignItems: 'center',
-  padding: '0 12px',
-  background: 'var(--bg-surface)',
-  borderTop: '1px solid rgba(var(--tint-rgb), 0.08)',
+  padding: '0 14px',
+  background: 'var(--bg-panel)',
+  borderTop: '1px solid rgba(var(--tint-rgb), 0.06)',
   cursor: 'pointer',
   flexShrink: 0,
   userSelect: 'none',

--- a/src/renderer/components/SplitPane.tsx
+++ b/src/renderer/components/SplitPane.tsx
@@ -97,15 +97,16 @@ export function SplitPane({
     ...(isHorizontal
       ? { width: 'var(--divider-size)', cursor: collapsed ? 'default' : 'col-resize' }
       : { height: 'var(--divider-size)', cursor: collapsed ? 'default' : 'row-resize' }),
-    background: 'rgba(var(--tint-rgb), 0.08)',
+    background: 'rgba(var(--tint-rgb), 0.06)',
     zIndex: 2,
+    transition: 'background var(--transition-fast)',
   };
 
   const dividerHitAreaStyle: React.CSSProperties = {
     position: 'absolute',
     ...(isHorizontal
-      ? { top: 0, bottom: 0, left: '-3px', right: '-3px' }
-      : { left: 0, right: 0, top: '-3px', bottom: '-3px' }),
+      ? { top: 0, bottom: 0, left: '-4px', right: '-4px' }
+      : { left: 0, right: 0, top: '-4px', bottom: '-4px' }),
     zIndex: 3,
   };
 
@@ -126,7 +127,7 @@ export function SplitPane({
       }}
     >
       <div style={{ ...firstStyle, overflow: 'hidden' }}>{children[0]}</div>
-      <div style={dividerStyle} onMouseDown={handleMouseDown}>
+      <div data-divider style={dividerStyle} onMouseDown={handleMouseDown}>
         <div style={dividerHitAreaStyle} />
       </div>
       <div style={{ ...secondStyle, overflow: 'hidden' }}>{children[1]}</div>

--- a/src/renderer/components/StatusBar.tsx
+++ b/src/renderer/components/StatusBar.tsx
@@ -16,9 +16,11 @@ const statusColors: Record<string, string> = {
   ended: 'var(--status-ended)',
 };
 
+const pulsingStatuses = new Set(['thinking', 'generating', 'waiting']);
+
 function StatusDot({ status }: { status: string }): React.ReactElement {
   const color = statusColors[status] ?? 'var(--text-dimmed)';
-  const isPulsing = status === 'thinking' || status === 'generating';
+  const isPulsing = pulsingStatuses.has(status);
 
   return (
     <span
@@ -28,9 +30,10 @@ function StatusDot({ status }: { status: string }): React.ReactElement {
         height: 7,
         borderRadius: '50%',
         backgroundColor: color,
-        marginRight: 6,
+        marginRight: 7,
         animation: isPulsing ? 'statusPulse 1.5s ease-in-out infinite' : undefined,
         boxShadow: isPulsing ? `0 0 6px ${color}` : undefined,
+        transition: 'background-color var(--transition-fast)',
       }}
     />
   );
@@ -59,10 +62,12 @@ export function StatusBar({ session }: StatusBarProps): React.ReactElement {
       {/* Left — Status */}
       <div style={sectionStyle}>
         <StatusDot status={session.status} />
-        <span style={{ color: statusColors[session.status] ?? 'var(--text-dimmed)', textTransform: 'capitalize' }}>
+        <span style={{ color: statusColors[session.status] ?? 'var(--text-dimmed)', textTransform: 'capitalize', fontWeight: 500 }}>
           {session.status}
         </span>
       </div>
+
+      <span style={separatorDotStyle}>·</span>
 
       {/* Center — Name + CWD + tags */}
       <div style={centerStyle}>
@@ -89,13 +94,13 @@ export function StatusBar({ session }: StatusBarProps): React.ReactElement {
       {/* Right — Model + Context */}
       <div style={sectionStyle}>
         {session.model && (
-          <span style={{ color: 'var(--text-secondary)', whiteSpace: 'nowrap' }}>
+          <span style={{ color: 'var(--text-dimmed)', whiteSpace: 'nowrap', fontSize: 10, letterSpacing: '0.02em' }}>
             {shortenModel(session.model)}
           </span>
         )}
 
         {session.contextUsage != null && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
             <div style={contextBarTrackStyle}>
               <div
                 style={{
@@ -169,10 +174,17 @@ const tagStyle: React.CSSProperties = {
   WebkitAppRegion: 'no-drag',
 };
 
+const separatorDotStyle: React.CSSProperties = {
+  color: 'var(--text-dimmed)',
+  opacity: 0.5,
+  fontSize: 11,
+  flexShrink: 0,
+};
+
 const contextBarTrackStyle: React.CSSProperties = {
-  width: 48,
+  width: 52,
   height: 4,
-  background: 'rgba(var(--tint-rgb), 0.08)',
+  background: 'rgba(var(--tint-rgb), 0.10)',
   borderRadius: 2,
   overflow: 'hidden',
 };

--- a/src/renderer/components/ToolkitPanel.tsx
+++ b/src/renderer/components/ToolkitPanel.tsx
@@ -446,7 +446,7 @@ const headerStyle: React.CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   padding: '8px 14px',
-  borderTop: '1px solid var(--border-subtle)',
+  borderBottom: '1px solid var(--border-subtle)',
   flexShrink: 0,
 };
 
@@ -456,15 +456,15 @@ const addButtonStyle: React.CSSProperties = {
   height: 22,
   borderRadius: 'var(--radius-sm)',
   border: 'none',
-  background: 'var(--bg-hover)',
-  color: 'var(--text-secondary)',
-  fontSize: 15,
+  background: 'transparent',
+  color: 'var(--text-dimmed)',
+  fontSize: 16,
   lineHeight: 1,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   cursor: 'pointer',
-  transition: 'all var(--transition-fast)',
+  transition: 'color var(--transition-fast)',
 };
 
 const gridStyle: React.CSSProperties = {


### PR DESCRIPTION
## Summary
- Refine session cards: accent-colored unread names, hasUserInput dot, waiting status pulses green
- Polish status bar: dot separator, refined model text, wider context bar
- Improve shell header: SVG chevron, consistent background
- Consistent section header padding, transparent `+` buttons

Closes #17

## Test plan
- [x] Verify unread session name shows in accent color, reverts on read
- [x] Verify `hasUserInput` dimmed dot appears for new sessions without input
- [x] Verify `waiting` status shows green pulsing dot in both session card and status bar
- [x] Verify shell panel chevron rotates on collapse/expand
- [x] Verify toolkit and session headers have consistent spacing
- [x] Test across multiple themes (dark + light)

🤖 Generated with [Claude Code](https://claude.com/claude-code)