### PR TITLE
Add MesloLGS NF as default terminal font

### DIFF
--- a/src/main/session-store.ts
+++ b/src/main/session-store.ts
@@ -38,7 +38,7 @@ const DEFAULT_NEW_SESSION_DEFAULTS: NewSessionDefaults = {
 };
 
 const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
-  fontFamily: "'JetBrains Mono', 'IBM Plex Mono', 'SF Mono', 'Fira Code', monospace",
+  fontFamily: "'MesloLGS NF', 'JetBrains Mono', 'IBM Plex Mono', 'SF Mono', 'Fira Code', monospace",
   theme: 'espresso',
 };
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -24,7 +24,7 @@ export function App(): React.ReactElement {
   const [shellCollapsed, setShellCollapsed] = useState(false);
   const [showNewSession, setShowNewSession] = useState(false);
   const [showPreferences, setShowPreferences] = useState(false);
-  const [terminalFontFamily, setTerminalFontFamily] = useState("'JetBrains Mono', 'IBM Plex Mono', 'SF Mono', 'Fira Code', monospace");
+  const [terminalFontFamily, setTerminalFontFamily] = useState("'MesloLGS NF', 'JetBrains Mono', 'IBM Plex Mono', 'SF Mono', 'Fira Code', monospace");
   const [endSessionConfirm, setEndSessionConfirm] = useState<string | null>(null);
   const [currentTheme, setCurrentTheme] = useState(DEFAULT_THEME_ID);
   const [ptySearch, setPtySearch] = useState<{ sessionId: string; key: number } | null>(null);

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -7,7 +7,7 @@ import '@xterm/xterm/css/xterm.css';
 import { getTheme, DEFAULT_THEME_ID } from '../themes';
 import type { XtermColors, SearchDecorations } from '../themes';
 
-const DEFAULT_FONT_FAMILY = "'JetBrains Mono', 'IBM Plex Mono', 'SF Mono', 'Fira Code', monospace";
+const DEFAULT_FONT_FAMILY = "'MesloLGS NF', 'JetBrains Mono', 'IBM Plex Mono', 'SF Mono', 'Fira Code', monospace";
 
 interface TerminalViewProps {
   sessionId: string | null;

--- a/src/renderer/theme.css
+++ b/src/renderer/theme.css
@@ -52,7 +52,7 @@
   --divider-hit-area: 6px;
 
   /* Typography */
-  --font-mono: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
+  --font-mono: 'MesloLGS NF', 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
   --font-ui: -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif;
 
   /* Transitions */


### PR DESCRIPTION
## Summary

- Add `'MesloLGS NF'` to the front of the default terminal font family across all 4 declaration sites
- Ensures Nerd Font glyphs (powerline symbols, icons) render correctly when the font is installed

Closes #23

## Changed files

| File | Change |
|------|--------|
| `src/main/session-store.ts` | Persisted default settings |
| `src/renderer/App.tsx` | React state initial value |
| `src/renderer/theme.css` | CSS `--font-mono` variable |
| `src/renderer/components/TerminalView.tsx` | Terminal fallback constant |

## Test plan

- [ ] Launch app with MesloLGS NF installed — terminal should use it
- [ ] Launch app without MesloLGS NF — falls back to JetBrains Mono as before
- [ ] Change font in Preferences — custom font still takes effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)