### PR TITLE
Sync session names between Chorus and Claude Code

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -198,7 +198,7 @@ async function createSessionFromConfig(
 
   // Use --session-id so Claude Code uses our ID (enables precise resume later)
   // If worktree specified, let Claude Code handle worktree creation via --worktree flag
-  const spawnFlags = [...config.flags, "--session-id", id];
+  const spawnFlags = [...config.flags, "--session-id", id, "--name", config.name];
   if (worktree && !worktreeDirExists) {
     spawnFlags.push("--worktree", worktree);
   }
@@ -486,6 +486,12 @@ function registerIpcHandlers(): void {
           `Session not found: ${payload.id}`,
         );
       sessionStore.persistSessions();
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send(IpcChannels.SESSION_STATE, {
+          sessionId: payload.id,
+          name: payload.name,
+        });
+      }
       return session;
     },
   );

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -40,13 +40,14 @@ export class PtyManager {
     const defaultRows = 30;
 
     // Build claude command args — only allow flags starting with -,
-    // plus value arguments that follow --session-id or --resume
+    // plus value arguments that follow known valued flags
+    const valuedFlags = new Set(['--session-id', '--resume', '--worktree', '--name']);
     const claudeArgs: string[] = [];
     for (let i = 0; i < flags.length; i++) {
       const f = flags[i];
       if (f.startsWith('-')) {
         claudeArgs.push(f);
-        if ((f === '--session-id' || f === '--resume' || f === '--worktree') && i + 1 < flags.length) {
+        if (valuedFlags.has(f) && i + 1 < flags.length) {
           claudeArgs.push(flags[++i]);
         }
       }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -89,6 +89,7 @@ export function App(): React.ReactElement {
                 ...(update.gitBranch !== undefined && { gitBranch: update.gitBranch }),
                 ...(update.hasUserInput !== undefined && { hasUserInput: update.hasUserInput }),
                 ...(update.unread !== undefined && { unread: update.unread }),
+                ...(update.name !== undefined && { name: update.name }),
               }
             : s
         )
@@ -254,9 +255,7 @@ export function App(): React.ReactElement {
 
   const handleRenameSession = useCallback(
     (id: string, newName: string) => {
-      window.electronAPI.sessionRename(id, newName).then((updated) => {
-        setSessions((prev) => prev.map((s) => (s.id === id ? updated : s)));
-      });
+      window.electronAPI.sessionRename(id, newName);
     },
     []
   );

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -180,6 +180,18 @@ export function TerminalView({ sessionId, type, visible = true, fontFamily }: Te
       }
     });
 
+    // Sync terminal title changes (e.g. Claude Code /rename) back to Chorus session name
+    if (type === 'pty') {
+      let lastTitle = '';
+      terminal.onTitleChange((title: string) => {
+        const trimmed = title.trim();
+        if (trimmed && trimmed !== lastTitle) {
+          lastTitle = trimmed;
+          window.electronAPI.sessionRename(sid, trimmed);
+        }
+      });
+    }
+
     const entry: TerminalEntry = { terminal, fitAddon, searchAddon, searchResult, mountedIn: null, opened: false, removeDataListener };
     terminalCache.set(key, entry);
     return entry;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -41,6 +41,7 @@ export interface SessionStateUpdate {
   gitBranch?: string | null;
   hasUserInput?: boolean;
   unread?: boolean;
+  name?: string;
 }
 
 // ─── Persistence (subset of Session saved to disk) ──────

--- a/tests/pty-manager.test.ts
+++ b/tests/pty-manager.test.ts
@@ -68,6 +68,13 @@ describe('PtyManager', () => {
       expect(firstCall[1]).toContain('uuid-abc-123');
     });
 
+    it('should pass --name with its value argument', () => {
+      manager.spawn('session-1', '/tmp/test', ['--name', 'My Session']);
+      const firstCall = nodePty.spawn.mock.calls[0];
+      expect(firstCall[1]).toContain('--name');
+      expect(firstCall[1]).toContain('My Session');
+    });
+
     it('should pass --resume with its value argument', () => {
       manager.spawn('session-1', '/tmp/test', ['--resume', 'uuid-abc-123']);
       const firstCall = nodePty.spawn.mock.calls[0];


### PR DESCRIPTION
## Summary
- Pass `--name` CLI flag to Claude Code on session creation so the user-entered name is reflected in Claude Code
- Detect terminal title changes (OSC sequences from Claude Code `/rename`) via xterm.js `onTitleChange` and sync them back to update the Chorus sidebar
- Dedup guard (`lastTitle` + `trim()`) prevents no-op IPC roundtrips and whitespace-only renames

## Honest disclaimer

We ran `tsc --noEmit` (zero errors) and `vitest run` (209/209 passed), but let's be real — no actual humans were harmed or involved in the manual testing of this feature. The TypeScript compiler said it's fine, and who are we to argue with a compiler? That said, it would be *greatly appreciated* if a real human (looking at you @a179346) could give this a spin — create a session, check that Claude Code picks up the name, try `/rename` inside Claude Code, and confirm the sidebar updates. We trust the machines, but we trust you more. Barely.

## Test plan
- [ ] Create a new session with a custom name → verify Claude Code shows that name (check `/status`)
- [ ] Use `/rename "New Name"` inside Claude Code → verify Chorus sidebar updates
- [ ] Rename from Chorus sidebar (right-click) → verify it still works as before
- [ ] Restore sessions (quit & reopen) → verify names sync back from Claude Code on resume
- [ ] Rapid title changes don't spam IPC (dedup guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)