### PR TITLE
Add --dangerously-skip-permissions flag toggle to New Session dialog

### DIFF
--- a/src/renderer/components/NewSessionDialog.tsx
+++ b/src/renderer/components/NewSessionDialog.tsx
@@ -11,6 +11,7 @@ export function NewSessionDialog({ open, onClose, onSubmit }: NewSessionDialogPr
   const [cwd, setCwd] = useState('');
   const [worktree, setWorktree] = useState('');
   const [autoMode, setAutoMode] = useState(false);
+  const [skipPermissions, setSkipPermissions] = useState(false);
   const [chrome, setChrome] = useState(false);
   const [notifyOnIdle, setNotifyOnIdle] = useState(false);
   const nameRef = useRef<HTMLInputElement>(null);
@@ -21,6 +22,7 @@ export function NewSessionDialog({ open, onClose, onSubmit }: NewSessionDialogPr
     window.electronAPI.appGetNewSessionDefaults().then((defaults) => {
       setCwd(defaults.cwd || '');
       setAutoMode(defaults.flags.includes('--enable-auto-mode'));
+      setSkipPermissions(defaults.flags.includes('--dangerously-skip-permissions'));
       setChrome(defaults.flags.includes('--chrome'));
       setNotifyOnIdle(defaults.notifyOnIdle ?? false);
     });
@@ -70,10 +72,11 @@ export function NewSessionDialog({ open, onClose, onSubmit }: NewSessionDialogPr
       if (!name.trim() || !cwd.trim()) return;
       const flags: string[] = [];
       if (autoMode) flags.push('--enable-auto-mode');
+      if (skipPermissions) flags.push('--dangerously-skip-permissions');
       flags.push(chrome ? '--chrome' : '--no-chrome');
       onSubmit({ name: name.trim(), cwd: cwd.trim(), worktree: worktree.trim(), flags, notifyOnIdle });
     },
-    [name, cwd, worktree, autoMode, chrome, notifyOnIdle, onSubmit]
+    [name, cwd, worktree, autoMode, skipPermissions, chrome, notifyOnIdle, onSubmit]
   );
 
   if (!open) return null;
@@ -140,6 +143,25 @@ export function NewSessionDialog({ open, onClose, onSubmit }: NewSessionDialogPr
               onClick={() => setAutoMode(!autoMode)}
             >
               Enable auto mode
+            </label>
+          </div>
+
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <div
+              style={{
+                ...checkboxStyle,
+                background: skipPermissions ? 'var(--status-error, #e53e3e)' : 'var(--bg-surface)',
+                borderColor: skipPermissions ? 'var(--status-error, #e53e3e)' : 'var(--border-default)',
+              }}
+              onClick={() => setSkipPermissions(!skipPermissions)}
+            >
+              {skipPermissions && <span style={{ fontSize: 10, lineHeight: 1 }}>✓</span>}
+            </div>
+            <label
+              style={{ fontSize: 11, color: skipPermissions ? 'var(--status-error, #e53e3e)' : 'var(--text-secondary)', cursor: 'pointer', userSelect: 'none' }}
+              onClick={() => setSkipPermissions(!skipPermissions)}
+            >
+              Skip permissions
             </label>
           </div>
 

--- a/tests/pty-manager.test.ts
+++ b/tests/pty-manager.test.ts
@@ -82,6 +82,12 @@ describe('PtyManager', () => {
       expect(firstCall[1]).toContain('uuid-abc-123');
     });
 
+    it('should spawn claude with --dangerously-skip-permissions flag', () => {
+      manager.spawn('session-1', '/tmp/test', ['--dangerously-skip-permissions']);
+      const firstCall = nodePty.spawn.mock.calls[0];
+      expect(firstCall[1]).toContain('--dangerously-skip-permissions');
+    });
+
     it('should combine --session-id with other flags', () => {
       manager.spawn('session-1', '/tmp/test', ['--enable-auto-mode', '--session-id', 'uuid-123']);
       const firstCall = nodePty.spawn.mock.calls[0];

--- a/tests/session-store.test.ts
+++ b/tests/session-store.test.ts
@@ -266,6 +266,19 @@ describe('SessionStore', () => {
       expect(defaults.cwd).toBe('/home/user');
       expect(defaults.flags).toContain('--enable-auto-mode');
     });
+
+    it('should persist --dangerously-skip-permissions in new session defaults', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({
+          windowBounds: { x: 0, y: 0, width: 800, height: 600 },
+          panelSizes: { sidebarWidth: 300, shellHeight: 200, toolkitHeight: 200, shellCollapsed: false },
+          lastActiveSessionId: null,
+          newSessionDefaults: { cwd: '/tmp', flags: ['--dangerously-skip-permissions'] },
+        })
+      );
+      const defaults = store.getNewSessionDefaults();
+      expect(defaults.flags).toContain('--dangerously-skip-permissions');
+    });
   });
 
   describe('toolkit commands', () => {


### PR DESCRIPTION
## Summary
- Added a "Skip permissions" checkbox in the New Session dialog that passes `--dangerously-skip-permissions` to the Claude CLI
- Checkbox uses red color when active as a visual warning for the dangerous option
- Flag is persisted in new session defaults, following the same pattern as `--enable-auto-mode`

Closes #28

## Test plan
- [x] All existing tests pass (211/211)
- [x] TypeScript type-check passes
- [x] Open New Session dialog → toggle "Skip permissions" → verify checkbox turns red
- [x] Create session with flag enabled → verify `claude` is spawned with `--dangerously-skip-permissions`
- [x] Close and reopen dialog → verify the flag is remembered from last session

🤖 Generated with [Claude Code](https://claude.com/claude-code)