### PR TITLE
Auto-detect PR stage per session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "chorus",
-  "version": "0.1.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chorus",
-      "version": "0.1.0",
+      "version": "1.3.0",
       "hasInstallScript": true,
-      "license": "ISC",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -19,6 +19,7 @@
         "@xterm/xterm": "^5.5.0",
         "lucide-react": "^1.7.0",
         "node-pty": "^1.1.0-beta22",
+        "p-limit": "^7.3.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -4090,6 +4091,35 @@
         "p-limit": "^3.1.0 "
       }
     },
+    "node_modules/dir-compare/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dir-compare/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ds-store": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ds-store/-/ds-store-0.1.6.tgz",
@@ -6894,6 +6924,37 @@
       }
     },
     "node_modules/p-limit": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
@@ -6909,15 +6970,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
       "engines": {
         "node": ">=10"
       },
@@ -9256,13 +9314,12 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@xterm/xterm": "^5.5.0",
     "lucide-react": "^1.7.0",
     "node-pty": "^1.1.0-beta22",
+    "p-limit": "^7.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/main/hook-server.ts
+++ b/src/main/hook-server.ts
@@ -2,8 +2,8 @@ import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import type { SessionStatus } from '../shared/types';
-import { readTranscriptMetadata } from './transcript-reader';
+import type { PrRef, SessionStatus } from '../shared/types';
+import { extractPrFromCreateCall, readTranscriptMetadata } from './transcript-reader';
 
 export interface HookEvent {
   session_id: string;
@@ -39,18 +39,21 @@ export interface HookUpdate {
 }
 
 export type HookStatusCallback = (sessionId: string, update: HookUpdate) => void;
+export type PrDetectedCallback = (sessionId: string, pr: PrRef) => void;
 
 export class HookServer {
   private server: http.Server | null = null;
   private port = 0;
   private callback: HookStatusCallback;
+  private prCallback: PrDetectedCallback | null = null;
   /** Tracks which cwd directories have had hooks installed this session. */
   private installedDirs: Set<string> = new Set();
   /** Maps session ID -> transcript path. */
   private transcriptPaths: Map<string, string> = new Map();
 
-  constructor(callback: HookStatusCallback) {
+  constructor(callback: HookStatusCallback, prCallback?: PrDetectedCallback) {
     this.callback = callback;
+    this.prCallback = prCallback ?? null;
   }
 
   /** Start the HTTP server on a random available port. */
@@ -213,25 +216,38 @@ export class HookServer {
       return;
     }
 
-    // On Stop, read transcript for updated model + context usage
+    // On Stop, read transcript for updated model + context usage + PR detection
     if (event.hook_event_name === 'Stop') {
       // Emit status immediately so UI updates fast
       this.callback(event.session_id, { status });
 
-      // Wait briefly for Claude Code to flush the transcript, then read metadata
+      // Wait briefly for Claude Code to flush the transcript, then run both
+      // metadata + PR extraction in parallel against the freshly-flushed file.
       const transcriptPath = this.transcriptPaths.get(event.session_id);
       if (transcriptPath) {
-        new Promise((r) => setTimeout(r, 500)).then(() => readTranscriptMetadata(transcriptPath)).then((meta) => {
-          if (meta.model || meta.contextUsage !== null) {
-            this.callback(event.session_id, {
-              status,
-              model: meta.model ?? undefined,
-              contextUsage: meta.contextUsage ?? undefined,
-            });
-          }
-        }).catch(() => {
-          // Ignore transcript read failures
-        });
+        const sessionId = event.session_id;
+        new Promise((r) => setTimeout(r, 500))
+          .then(() =>
+            Promise.all([
+              readTranscriptMetadata(transcriptPath),
+              extractPrFromCreateCall(transcriptPath),
+            ]),
+          )
+          .then(([meta, pr]) => {
+            if (meta.model || meta.contextUsage !== null) {
+              this.callback(sessionId, {
+                status,
+                model: meta.model ?? undefined,
+                contextUsage: meta.contextUsage ?? undefined,
+              });
+            }
+            if (pr && this.prCallback) {
+              this.prCallback(sessionId, pr);
+            }
+          })
+          .catch(() => {
+            // Ignore transcript read failures
+          });
       }
       return;
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,8 +1,9 @@
 import { app, BrowserWindow, Menu, ipcMain, dialog, Notification, shell } from "electron";
 import path from "node:path";
 import fs from "node:fs";
-import { execSync } from "node:child_process";
+import { execSync, spawn } from "node:child_process";
 import crypto from "node:crypto";
+import pLimit from "p-limit";
 import { IpcChannels, IpcErrorCodes } from "../shared/ipc";
 import type {
   Session,
@@ -17,6 +18,8 @@ import type {
   ToolkitListPayload,
   ToolkitSavePayload,
   AppState,
+  PrRef,
+  SessionStage,
 } from "../shared/types";
 import { SessionStore } from "./session-store";
 import { PtyManager } from "./pty-manager";
@@ -75,6 +78,231 @@ if (!app.isPackaged) {
 const sessionStore = new SessionStore();
 let mainWindow: BrowserWindow | null = null;
 let activeSessionId: string | null = null;
+
+// ─── Stage Refresh ──────────────────────────────────────────
+
+const GH_TIMEOUT_MS = 10_000;
+const GH_RETRY_AFTER_MS = 5 * 60 * 1000;
+const STAGE_DEBOUNCE_MS = 1000;
+const STAGE_POLL_INTERVAL_MS = 60_000;
+
+const stageRefreshLimit = pLimit(4);
+const stageRefreshInFlight: Map<string, Promise<void>> = new Map();
+const stageRefreshDebouncers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+let ghAvailable = true;
+let ghUnavailableUntil = 0;
+
+type GhResult =
+  | { type: 'ok'; stage: SessionStage }
+  | { type: 'not-found' }
+  | { type: 'unavailable' }
+  | { type: 'error' };
+
+function deriveStage(json: {
+  state?: unknown;
+  isDraft?: unknown;
+  mergedAt?: unknown;
+}): SessionStage {
+  const state = typeof json.state === 'string' ? json.state.toUpperCase() : '';
+  const isDraft = json.isDraft === true;
+  const merged = json.mergedAt !== null && json.mergedAt !== undefined && json.mergedAt !== '';
+  if (state === 'MERGED' || merged) return 'merged';
+  if (state === 'CLOSED') return 'closed';
+  if (state === 'OPEN') return isDraft ? 'draft' : 'ready';
+  return 'no-pr';
+}
+
+function runGhPrView(pr: PrRef): Promise<GhResult> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (r: GhResult): void => {
+      if (settled) return;
+      settled = true;
+      resolve(r);
+    };
+
+    let child;
+    try {
+      child = spawn(
+        'gh',
+        [
+          'pr',
+          'view',
+          String(pr.number),
+          '-R',
+          `${pr.owner}/${pr.repo}`,
+          '--json',
+          'state,isDraft,mergedAt',
+        ],
+        { stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+    } catch {
+      settle({ type: 'unavailable' });
+      return;
+    }
+
+    let stdout = '';
+    let stderr = '';
+
+    const timeout = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        /* ignore */
+      }
+      settle({ type: 'error' });
+    }, GH_TIMEOUT_MS);
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      clearTimeout(timeout);
+      if (err.code === 'ENOENT') settle({ type: 'unavailable' });
+      else settle({ type: 'error' });
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timeout);
+      if (code === 0) {
+        try {
+          settle({ type: 'ok', stage: deriveStage(JSON.parse(stdout)) });
+        } catch {
+          settle({ type: 'error' });
+        }
+        return;
+      }
+      const msg = stderr.toLowerCase();
+      if (msg.includes('not authenticated') || msg.includes('command not found')) {
+        settle({ type: 'unavailable' });
+      } else if (msg.includes('not found') || msg.includes('could not resolve')) {
+        settle({ type: 'not-found' });
+      } else {
+        settle({ type: 'error' });
+      }
+    });
+  });
+}
+
+function pushSessionState(payload: Record<string, unknown> & { sessionId: string }): void {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send(IpcChannels.SESSION_STATE, payload);
+  }
+}
+
+function refreshStage(sessionId: string): Promise<void> {
+  const session = sessionStore.getSession(sessionId);
+  if (!session || !session.pr || session.status === 'ended') return Promise.resolve();
+
+  const existing = stageRefreshInFlight.get(sessionId);
+  if (existing) return existing;
+
+  if (!ghAvailable && Date.now() < ghUnavailableUntil) return Promise.resolve();
+
+  const promise = stageRefreshLimit(async () => {
+    const s = sessionStore.getSession(sessionId);
+    if (!s || !s.pr || s.status === 'ended') return;
+
+    const result = await runGhPrView(s.pr);
+
+    const after = sessionStore.getSession(sessionId);
+    if (!after || after.status === 'ended') return;
+
+    if (result.type === 'unavailable') {
+      ghAvailable = false;
+      ghUnavailableUntil = Date.now() + GH_RETRY_AFTER_MS;
+      return;
+    }
+    if (result.type === 'error') return;
+
+    ghAvailable = true;
+    const ts = Date.now();
+
+    if (result.type === 'not-found') {
+      const changed = after.pr !== null || after.stage !== 'no-pr';
+      if (changed) {
+        sessionStore.updateSession(sessionId, {
+          pr: null,
+          stage: 'no-pr',
+          stageUpdatedAt: ts,
+        });
+        sessionStore.persistSessions();
+        pushSessionState({ sessionId, pr: null, stage: 'no-pr', stageUpdatedAt: ts });
+      } else {
+        after.stageUpdatedAt = ts;
+      }
+      return;
+    }
+
+    if (after.stage !== result.stage) {
+      sessionStore.updateSession(sessionId, {
+        stage: result.stage,
+        stageUpdatedAt: ts,
+      });
+      sessionStore.persistSessions();
+      pushSessionState({ sessionId, stage: result.stage, stageUpdatedAt: ts });
+    } else {
+      after.stageUpdatedAt = ts;
+    }
+  }).finally(() => {
+    stageRefreshInFlight.delete(sessionId);
+  });
+
+  stageRefreshInFlight.set(sessionId, promise);
+  return promise;
+}
+
+function scheduleRefresh(sessionId: string | null): void {
+  if (!sessionId) return;
+  const existing = stageRefreshDebouncers.get(sessionId);
+  if (existing) clearTimeout(existing);
+  stageRefreshDebouncers.set(
+    sessionId,
+    setTimeout(() => {
+      stageRefreshDebouncers.delete(sessionId);
+      void refreshStage(sessionId);
+    }, STAGE_DEBOUNCE_MS),
+  );
+}
+
+function cleanupStageRefresh(sessionId: string): void {
+  stageRefreshInFlight.delete(sessionId);
+  const t = stageRefreshDebouncers.get(sessionId);
+  if (t) {
+    clearTimeout(t);
+    stageRefreshDebouncers.delete(sessionId);
+  }
+}
+
+function refreshAllStages(): void {
+  for (const s of sessionStore.getAllSessions()) {
+    if (s.pr && s.status !== 'ended') void refreshStage(s.id);
+  }
+}
+
+function handlePrDetected(sessionId: string, pr: PrRef): void {
+  const session = sessionStore.getSession(sessionId);
+  if (!session || session.status === 'ended') return;
+  const current = session.pr;
+  if (
+    current &&
+    current.owner === pr.owner &&
+    current.repo === pr.repo &&
+    current.number === pr.number
+  ) {
+    void refreshStage(sessionId);
+    return;
+  }
+  sessionStore.updateSession(sessionId, { pr });
+  sessionStore.persistSessions();
+  pushSessionState({ sessionId, pr });
+  void refreshStage(sessionId);
+}
+
 const hookServer = new HookServer((sessionId, update) => {
   const updates: Partial<Session> = { status: update.status };
   if (update.status === "thinking") updates.hasUserInput = true;
@@ -128,7 +356,7 @@ const hookServer = new HookServer((sessionId, update) => {
     if (updates.unread !== undefined) payload.unread = updates.unread;
     mainWindow.webContents.send(IpcChannels.SESSION_STATE, payload);
   }
-});
+}, handlePrDetected);
 
 const ptyManager = new PtyManager();
 
@@ -186,6 +414,9 @@ async function createSessionFromConfig(
     createdAt: now,
     lastActiveAt: now,
     hasUserInput: false,
+    pr: null,
+    stage: "no-pr",
+    stageUpdatedAt: null,
   };
 
   const worktreeCwd = worktree
@@ -270,6 +501,7 @@ function createWindow(): void {
 
   mainWindow.on("focus", () => {
     if (!activeSessionId) return;
+    scheduleRefresh(activeSessionId);
     const session = sessionStore.getSession(activeSessionId);
     if (session?.unread) {
       session.unread = false;
@@ -507,6 +739,7 @@ function registerIpcHandlers(): void {
         );
       ptyManager.kill(payload.id);
       sessionStore.updateSession(payload.id, { status: "ended" });
+      cleanupStageRefresh(payload.id);
       sessionStore.removeSession(payload.id);
       sessionStore.persistSessions();
     },
@@ -524,6 +757,7 @@ function registerIpcHandlers(): void {
       activeSessionId = payload.id;
       sessionStore.saveAppState({ lastActiveSessionId: payload.id });
       session.lastActiveAt = Date.now();
+      scheduleRefresh(payload.id);
       if (session.unread) {
         session.unread = false;
         updateDockBadge();
@@ -726,6 +960,9 @@ function restoreSessions(): void {
         createdAt: ps.createdAt,
         lastActiveAt: ps.lastActiveAt,
         hasUserInput: ps.hasUserInput,
+        pr: ps.pr ?? null,
+        stage: ps.stage ?? "no-pr",
+        stageUpdatedAt: ps.stageUpdatedAt ?? null,
       };
       sessionStore.addSession(session);
     } catch {
@@ -749,6 +986,8 @@ app.whenReady().then(async () => {
   createWindow();
   restoreSessions();
 
+  refreshAllStages();
+  setInterval(refreshAllStages, STAGE_POLL_INTERVAL_MS);
 
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/src/main/session-store.ts
+++ b/src/main/session-store.ts
@@ -171,6 +171,9 @@ export class SessionStore {
         createdAt: s.createdAt,
         lastActiveAt: s.lastActiveAt,
         hasUserInput: s.hasUserInput,
+        pr: s.pr,
+        stage: s.stage,
+        stageUpdatedAt: s.stageUpdatedAt,
       };
       writeJson(sessionFilePath(s.id), persisted);
     }

--- a/src/main/transcript-reader.ts
+++ b/src/main/transcript-reader.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import type { PrRef } from '../shared/types';
 
 /** Known context window sizes by model family. */
 const CONTEXT_LIMITS: Record<string, number> = {
@@ -130,4 +131,114 @@ export async function readTranscriptMetadata(transcriptPath: string): Promise<Tr
   }
 
   return { model: null, contextUsage: null };
+}
+
+// ─── PR ref extraction ────────────────────────────────────
+
+const GH_PR_CREATE_REGEX = /(?:^|[\s;|&(])gh\s+pr\s+create\b/;
+const PR_URL_REGEX = /https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/pull\/(\d+)/g;
+
+function isCreatePrToolUse(block: unknown): boolean {
+  if (!block || typeof block !== 'object') return false;
+  const b = block as Record<string, unknown>;
+  if (b.type !== 'tool_use') return false;
+  if (b.name === 'mcp__github__create_pull_request') return true;
+  if (b.name === 'Bash') {
+    const input = b.input as Record<string, unknown> | undefined;
+    if (input && typeof input.command === 'string') {
+      return GH_PR_CREATE_REGEX.test(input.command);
+    }
+  }
+  return false;
+}
+
+function extractToolResultText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const block of content) {
+      if (block && typeof block === 'object' && (block as { type?: unknown }).type === 'text') {
+        const text = (block as { text?: unknown }).text;
+        if (typeof text === 'string') parts.push(text);
+      }
+    }
+    return parts.join('\n');
+  }
+  return '';
+}
+
+function extractLastPrUrl(text: string): PrRef | null {
+  const matches = [...text.matchAll(PR_URL_REGEX)];
+  if (matches.length === 0) return null;
+  const last = matches[matches.length - 1];
+  return {
+    owner: last[1],
+    repo: last[2],
+    number: parseInt(last[3], 10),
+  };
+}
+
+/**
+ * Scan the tail of a Claude Code transcript for the most recent successful
+ * `gh pr create` (or `mcp__github__create_pull_request`) tool call and return
+ * the PR ref parsed from its tool_result.
+ *
+ * Anchors on the create-PR tool_use itself (matched via tool_use_id) so that
+ * `gh pr list` / `gh pr view <other>` URLs in the same window cannot pollute
+ * the result.
+ *
+ * Returns null on any error (missing file, IO failure, malformed JSONL, no
+ * matching create call). Never throws.
+ */
+export async function extractPrFromCreateCall(
+  transcriptPath: string,
+  tailLines = 200,
+): Promise<PrRef | null> {
+  try {
+    if (!fs.existsSync(transcriptPath)) return null;
+
+    // readTailLines returns reverse order (newest first); flip to chronological
+    const reversed = readTailLines(transcriptPath, tailLines, 0);
+    const lines = reversed.slice().reverse();
+
+    // Walk lines in chronological order, collecting create-PR tool_use ids and
+    // tool_result text by tool_use_id. Same line can contain multiple blocks.
+    const createPrIds: string[] = [];
+    const resultByToolUseId = new Map<string, string>();
+
+    for (const line of lines) {
+      let entry: unknown;
+      try {
+        entry = JSON.parse(line);
+      } catch {
+        continue;
+      }
+
+      const message = (entry as { message?: { content?: unknown } } | null)?.message;
+      const content = message?.content;
+      if (!Array.isArray(content)) continue;
+
+      for (const block of content) {
+        if (!block || typeof block !== 'object') continue;
+        const b = block as Record<string, unknown>;
+        if (b.type === 'tool_use' && typeof b.id === 'string' && isCreatePrToolUse(b)) {
+          createPrIds.push(b.id);
+        } else if (b.type === 'tool_result' && typeof b.tool_use_id === 'string') {
+          resultByToolUseId.set(b.tool_use_id, extractToolResultText(b.content));
+        }
+      }
+    }
+
+    // Walk create ids latest-first, return first one with a matching PR URL
+    for (let i = createPrIds.length - 1; i >= 0; i--) {
+      const text = resultByToolUseId.get(createPrIds[i]);
+      if (!text) continue;
+      const ref = extractLastPrUrl(text);
+      if (ref) return ref;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -90,6 +90,9 @@ export function App(): React.ReactElement {
                 ...(update.hasUserInput !== undefined && { hasUserInput: update.hasUserInput }),
                 ...(update.unread !== undefined && { unread: update.unread }),
                 ...(update.name !== undefined && { name: update.name }),
+                ...(update.pr !== undefined && { pr: update.pr }),
+                ...(update.stage !== undefined && { stage: update.stage }),
+                ...(update.stageUpdatedAt !== undefined && { stageUpdatedAt: update.stageUpdatedAt }),
               }
             : s
         )

--- a/src/renderer/components/SessionList.tsx
+++ b/src/renderer/components/SessionList.tsx
@@ -15,6 +15,7 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { Session } from '../../shared/types';
+import { STAGE_ICON } from '../stage';
 
 interface SessionListProps {
   sessions: Session[];
@@ -369,6 +370,26 @@ function SessionCard({ session, isActive, isEditing, onClick, onContextMenu, onR
           />
         ) : (
           <span style={{ display: 'flex', alignItems: 'center', gap: 5, overflow: 'hidden', minWidth: 0 }}>
+            {session.stage !== 'no-pr' && STAGE_ICON[session.stage] && (() => {
+              const { Icon, color, background, tooltip } = STAGE_ICON[session.stage];
+              return (
+                <span
+                  title={tooltip}
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flexShrink: 0,
+                    color,
+                    background,
+                    borderRadius: 'var(--radius-sm)',
+                    padding: '2px 3px',
+                  }}
+                >
+                  <Icon size={13} />
+                </span>
+              );
+            })()}
             {session.unread ? (
               <span
                 title="Unread"

--- a/src/renderer/components/StatusBar.tsx
+++ b/src/renderer/components/StatusBar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { GitBranch } from 'lucide-react';
 import type { Session } from '../../shared/types';
+import { STAGE_ICON } from '../stage';
 
 interface StatusBarProps {
   session: Session | null;
@@ -89,6 +90,22 @@ export function StatusBar({ session }: StatusBarProps): React.ReactElement {
             {session.worktree}
           </span>
         )}
+        {session.stage !== 'no-pr' && STAGE_ICON[session.stage] && (() => {
+          const { Icon, color, background, tooltip } = STAGE_ICON[session.stage];
+          return (
+            <span
+              title={tooltip}
+              style={{
+                ...tagStyle,
+                background,
+                color,
+                padding: '3px 5px',
+              }}
+            >
+              <Icon size={13} />
+            </span>
+          );
+        })()}
       </div>
 
       {/* Right — Model + Context */}

--- a/src/renderer/stage.ts
+++ b/src/renderer/stage.ts
@@ -1,0 +1,39 @@
+import {
+  GitPullRequestDraft,
+  GitPullRequestCreate,
+  GitPullRequestArrow,
+  GitPullRequestClosed,
+} from 'lucide-react';
+import type { SessionStage } from '../shared/types';
+
+export const STAGE_ICON: Record<Exclude<SessionStage, 'no-pr'>, {
+  Icon: typeof GitPullRequestCreate;
+  color: string;
+  background: string;
+  tooltip: string;
+}> = {
+  draft: {
+    Icon: GitPullRequestDraft,
+    color: 'var(--text-secondary)',
+    background: 'rgba(var(--tint-rgb), 0.08)',
+    tooltip: 'Draft PR',
+  },
+  ready: {
+    Icon: GitPullRequestCreate,
+    color: 'var(--accent-green)',
+    background: 'rgba(var(--accent-rgb), 0.22)',
+    tooltip: 'PR ready for review',
+  },
+  merged: {
+    Icon: GitPullRequestArrow,
+    color: '#a78bfa',
+    background: 'rgba(var(--tint-rgb), 0.08)',
+    tooltip: 'PR merged',
+  },
+  closed: {
+    Icon: GitPullRequestClosed,
+    color: 'var(--accent-red)',
+    background: 'rgba(var(--tint-rgb), 0.08)',
+    tooltip: 'PR closed',
+  },
+};

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -9,6 +9,19 @@ export type SessionStatus =
   | 'error'
   | 'ended';
 
+export type SessionStage =
+  | 'no-pr'
+  | 'draft'
+  | 'ready'
+  | 'merged'
+  | 'closed';
+
+export interface PrRef {
+  owner: string;
+  repo: string;
+  number: number;
+}
+
 export interface Session {
   id: string;
   name: string;
@@ -24,6 +37,9 @@ export interface Session {
   createdAt: number;
   lastActiveAt: number;
   hasUserInput: boolean;
+  pr: PrRef | null;
+  stage: SessionStage;
+  stageUpdatedAt: number | null;
 }
 
 export interface SessionConfig {
@@ -42,6 +58,9 @@ export interface SessionStateUpdate {
   hasUserInput?: boolean;
   unread?: boolean;
   name?: string;
+  pr?: PrRef | null;
+  stage?: SessionStage;
+  stageUpdatedAt?: number | null;
 }
 
 // ─── Persistence (subset of Session saved to disk) ──────
@@ -59,6 +78,9 @@ export interface PersistedSession {
   createdAt: number;
   lastActiveAt: number;
   hasUserInput: boolean;
+  pr: PrRef | null;
+  stage: SessionStage;
+  stageUpdatedAt: number | null;
 }
 
 // ─── Toolkit ─────────────────────────────────────────────

--- a/tests/transcript-reader.test.ts
+++ b/tests/transcript-reader.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { extractPrFromCreateCall } from "../src/main/transcript-reader";
+
+function makeTempTranscript(lines: object[]): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "chorus-transcript-"));
+  const file = path.join(dir, "transcript.jsonl");
+  fs.writeFileSync(file, lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+  return file;
+}
+
+function rmFile(file: string): void {
+  try {
+    fs.rmSync(path.dirname(file), { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+describe("extractPrFromCreateCall", () => {
+  let file: string;
+
+  afterEach(() => {
+    if (file) rmFile(file);
+  });
+
+  it("returns null when transcript file does not exist", async () => {
+    expect(await extractPrFromCreateCall("/nonexistent/path.jsonl")).toBeNull();
+  });
+
+  it("matches plain `gh pr create` Bash command", async () => {
+    file = makeTempTranscript([
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", id: "u1", name: "Bash", input: { command: "gh pr create --title foo" } },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "u1",
+              content: "https://github.com/myorg/myrepo/pull/42\n",
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(await extractPrFromCreateCall(file)).toEqual({
+      owner: "myorg",
+      repo: "myrepo",
+      number: 42,
+    });
+  });
+
+  it("matches chained `cd worktree && gh pr create`", async () => {
+    file = makeTempTranscript([
+      {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "u1",
+              name: "Bash",
+              input: { command: "cd .claude/worktrees/feat && gh pr create --draft" },
+            },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            { type: "tool_result", tool_use_id: "u1", content: "Created PR\nhttps://github.com/o/r/pull/7" },
+          ],
+        },
+      },
+    ]);
+
+    expect(await extractPrFromCreateCall(file)).toEqual({ owner: "o", repo: "r", number: 7 });
+  });
+
+  it("handles tool_result content as array of blocks", async () => {
+    file = makeTempTranscript([
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "tool_use", id: "u1", name: "Bash", input: { command: "gh pr create" } }],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "u1",
+              content: [
+                { type: "text", text: "Creating PR..." },
+                { type: "text", text: "https://github.com/foo/bar/pull/99" },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(await extractPrFromCreateCall(file)).toEqual({ owner: "foo", repo: "bar", number: 99 });
+  });
+
+  it("ignores `gh pr list` / `gh pr view <other>` noise", async () => {
+    file = makeTempTranscript([
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", id: "u1", name: "Bash", input: { command: "gh pr list" } },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "u1",
+              content:
+                "https://github.com/x/y/pull/1\nhttps://github.com/x/y/pull/2\nhttps://github.com/x/y/pull/3\n",
+            },
+          ],
+        },
+      },
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", id: "u2", name: "Bash", input: { command: "gh pr view 555" } },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            { type: "tool_result", tool_use_id: "u2", content: "https://github.com/x/y/pull/555" },
+          ],
+        },
+      },
+    ]);
+
+    expect(await extractPrFromCreateCall(file)).toBeNull();
+  });
+
+  it("picks the create-PR result even when noise URLs are nearby", async () => {
+    file = makeTempTranscript([
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "tool_use", id: "list1", name: "Bash", input: { command: "gh pr list" } }],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "list1",
+              content: "https://github.com/x/y/pull/100\nhttps://github.com/x/y/pull/200",
+            },
+          ],
+        },
+      },
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "tool_use", id: "create1", name: "Bash", input: { command: "gh pr create" } }],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            { type: "tool_result", tool_use_id: "create1", content: "https://github.com/x/y/pull/300" },
+          ],
+        },
+      },
+    ]);
+
+    expect(await extractPrFromCreateCall(file)).toEqual({ owner: "x", repo: "y", number: 300 });
+  });
+
+  it("takes the latest of multiple successful create attempts", async () => {
+    file = makeTempTranscript([
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "tool_use", id: "c1", name: "Bash", input: { command: "gh pr create" } }],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [{ type: "tool_result", tool_use_id: "c1", content: "https://github.com/o/r/pull/1" }],
+        },
+      },
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "tool_use", id: "c2", name: "Bash", input: { command: "gh pr create" } }],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [{ type: "tool_result", tool_use_id: "c2", content: "https://github.com/o/r/pull/2" }],
+        },
+      },
+    ]);
+
+    expect(await extractPrFromCreateCall(file)).toEqual({ owner: "o", repo: "r", number: 2 });
+  });
+
+  it("falls back to earlier create when latest create has no URL (failed)", async () => {
+    file = makeTempTranscript([
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "tool_use", id: "ok", name: "Bash", input: { command: "gh pr create" } }],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [{ type: "tool_result", tool_use_id: "ok", content: "https://github.com/o/r/pull/7" }],
+        },
+      },
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "tool_use", id: "fail", name: "Bash", input: { command: "gh pr create" } }],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [{ type: "tool_result", tool_use_id: "fail", content: "error: branch not found" }],
+        },
+      },
+    ]);
+
+    expect(await extractPrFromCreateCall(file)).toEqual({ owner: "o", repo: "r", number: 7 });
+  });
+
+  it("matches mcp__github__create_pull_request tool name", async () => {
+    file = makeTempTranscript([
+      {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "m1",
+              name: "mcp__github__create_pull_request",
+              input: { title: "x" },
+            },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            { type: "tool_result", tool_use_id: "m1", content: "Created: https://github.com/o/r/pull/55" },
+          ],
+        },
+      },
+    ]);
+
+    expect(await extractPrFromCreateCall(file)).toEqual({ owner: "o", repo: "r", number: 55 });
+  });
+
+  it("handles multiple tool_use in same JSONL line", async () => {
+    file = makeTempTranscript([
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "doing stuff" },
+            { type: "tool_use", id: "a", name: "Bash", input: { command: "ls" } },
+            { type: "tool_use", id: "b", name: "Bash", input: { command: "gh pr create --draft" } },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            { type: "tool_result", tool_use_id: "a", content: "file1\nfile2" },
+            { type: "tool_result", tool_use_id: "b", content: "https://github.com/o/r/pull/9" },
+          ],
+        },
+      },
+    ]);
+
+    expect(await extractPrFromCreateCall(file)).toEqual({ owner: "o", repo: "r", number: 9 });
+  });
+
+  it("returns null for malformed JSONL lines", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "chorus-transcript-"));
+    file = path.join(dir, "transcript.jsonl");
+    fs.writeFileSync(file, "{not valid json\n{also bad\n");
+
+    expect(await extractPrFromCreateCall(file)).toBeNull();
+  });
+
+  it("returns null when no PR create call is found", async () => {
+    file = makeTempTranscript([
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "just thinking" }],
+        },
+      },
+    ]);
+
+    expect(await extractPrFromCreateCall(file)).toBeNull();
+  });
+
+  it("does not match `gh pr ready` or other gh subcommands", async () => {
+    file = makeTempTranscript([
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", id: "u1", name: "Bash", input: { command: "gh pr ready 42" } },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            { type: "tool_result", tool_use_id: "u1", content: "https://github.com/o/r/pull/42" },
+          ],
+        },
+      },
+    ]);
+
+    expect(await extractPrFromCreateCall(file)).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #33

## Summary
- Detects PR creation by scanning transcript JSONL on the `Stop` hook for `gh pr create` / `mcp__github__create_pull_request` tool calls, anchored on `tool_use_id` so `gh pr list` / `gh pr view <other>` noise can't pollute the result.
- Polls `gh pr view --json state,isDraft,mergedAt` to derive `SessionStage` (no-pr / draft / ready / merged / closed). Triggered on detect, session switch, window focus (1s debounce), and a 60s background poll that also runs once at cold start. Single-flight per session, `pLimit(4)` global concurrency cap, 10s timeout, 5 min global short-circuit when `gh` is unavailable.
- Renders stage icon on session card and in the top status bar; `pr / stage / stageUpdatedAt` persist across restarts so the icon is correct immediately on cold start.

## Test plan
- [x] `npx vitest run` — 224/224 pass (13 new tests for `extractPrFromCreateCall`)
- [x] `npx tsc --noEmit` clean
- [ ] Manual: `gh pr create` in a session → icon flips to draft/ready
- [ ] Manual: merge / close PR on GitHub → icon updates within 60s, immediately on focus
- [ ] Manual: `gh` not on PATH → no error spam, icons don't disappear
- [ ] Manual: restart app with active PR session → stage icon visible immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)