### PR TITLE
Update PR stage icons for ready and merged states

### DIFF
--- a/src/renderer/stage.ts
+++ b/src/renderer/stage.ts
@@ -1,13 +1,13 @@
 import {
   GitPullRequestDraft,
-  GitPullRequestCreate,
   GitPullRequestArrow,
+  GitMerge,
   GitPullRequestClosed,
 } from 'lucide-react';
 import type { SessionStage } from '../shared/types';
 
 export const STAGE_ICON: Record<Exclude<SessionStage, 'no-pr'>, {
-  Icon: typeof GitPullRequestCreate;
+  Icon: typeof GitPullRequestArrow;
   color: string;
   background: string;
   tooltip: string;
@@ -19,13 +19,13 @@ export const STAGE_ICON: Record<Exclude<SessionStage, 'no-pr'>, {
     tooltip: 'Draft PR',
   },
   ready: {
-    Icon: GitPullRequestCreate,
+    Icon: GitPullRequestArrow,
     color: 'var(--accent-green)',
     background: 'rgba(var(--accent-rgb), 0.22)',
     tooltip: 'PR ready for review',
   },
   merged: {
-    Icon: GitPullRequestArrow,
+    Icon: GitMerge,
     color: '#a78bfa',
     background: 'rgba(var(--tint-rgb), 0.08)',
     tooltip: 'PR merged',


### PR DESCRIPTION
## Summary
- Change `ready` stage icon from `GitPullRequestCreate` to `GitPullRequestArrow`
- Change `merged` stage icon from `GitPullRequestArrow` to `GitMerge`

## Test plan
- [ ] Visually confirm session cards show the new ready icon
- [ ] Visually confirm session cards show the new merged icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)