### PR TITLE
Add terminal font size preferences

### DIFF
--- a/src/main/session-store.ts
+++ b/src/main/session-store.ts
@@ -40,6 +40,8 @@ const DEFAULT_NEW_SESSION_DEFAULTS: NewSessionDefaults = {
 const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   fontFamily: "'MesloLGS NF', 'JetBrains Mono', 'IBM Plex Mono', 'SF Mono', 'Fira Code', monospace",
   theme: 'espresso',
+  claudeFontSize: 13,
+  shellFontSize: 13,
 };
 
 const DEFAULT_APP_STATE: AppState = {
@@ -208,7 +210,16 @@ export class SessionStore {
   // ─── App State ────────────────────────────────────────────
 
   loadAppState(): AppState {
-    return readJson<AppState>(STATE_FILE, DEFAULT_APP_STATE);
+    const loaded = readJson<Partial<AppState> | null>(STATE_FILE, null);
+    if (!loaded || typeof loaded !== 'object') return DEFAULT_APP_STATE;
+    return {
+      ...DEFAULT_APP_STATE,
+      ...loaded,
+      windowBounds: { ...DEFAULT_APP_STATE.windowBounds, ...(loaded.windowBounds ?? {}) },
+      panelSizes: { ...DEFAULT_APP_STATE.panelSizes, ...(loaded.panelSizes ?? {}) },
+      newSessionDefaults: { ...DEFAULT_APP_STATE.newSessionDefaults, ...(loaded.newSessionDefaults ?? {}) },
+      terminalSettings: { ...DEFAULT_APP_STATE.terminalSettings, ...(loaded.terminalSettings ?? {}) },
+    };
   }
 
   saveAppState(partial: Partial<AppState>): void {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -5,7 +5,7 @@ import { StatusBar } from './components/StatusBar';
 import { ShellPanel } from './components/ShellPanel';
 import { SessionList } from './components/SessionList';
 import { ToolkitPanel } from './components/ToolkitPanel';
-import { TerminalView, disposeTerminal, focusTerminal, getFocusedTerminalInfo, setAllTerminalsFontFamily } from './components/TerminalView';
+import { TerminalView, disposeTerminal, focusTerminal, getFocusedTerminalInfo, applyTerminalSettings } from './components/TerminalView';
 import { SearchBar } from './components/SearchBar';
 import { NewSessionDialog } from './components/NewSessionDialog';
 import { PreferencesDialog } from './components/PreferencesDialog';
@@ -15,6 +15,7 @@ import { setTerminalTheme } from './components/TerminalView';
 const DEFAULT_SIDEBAR_WIDTH = 320;
 const DEFAULT_SHELL_HEIGHT = 200;
 const DEFAULT_TOOLKIT_HEIGHT = 200;
+const DEFAULT_FONT_SIZE = 13;
 
 export function App(): React.ReactElement {
   // ─── State ──────────────────────────────────────────
@@ -25,6 +26,8 @@ export function App(): React.ReactElement {
   const [showNewSession, setShowNewSession] = useState(false);
   const [showPreferences, setShowPreferences] = useState(false);
   const [terminalFontFamily, setTerminalFontFamily] = useState("'MesloLGS NF', 'JetBrains Mono', 'IBM Plex Mono', 'SF Mono', 'Fira Code', monospace");
+  const [claudeFontSize, setClaudeFontSize] = useState(DEFAULT_FONT_SIZE);
+  const [shellFontSize, setShellFontSize] = useState(DEFAULT_FONT_SIZE);
   const [endSessionConfirm, setEndSessionConfirm] = useState<string | null>(null);
   const [currentTheme, setCurrentTheme] = useState(DEFAULT_THEME_ID);
   const [ptySearch, setPtySearch] = useState<{ sessionId: string; key: number } | null>(null);
@@ -55,6 +58,12 @@ export function App(): React.ReactElement {
       }
       if (state.terminalSettings?.fontFamily) {
         setTerminalFontFamily(state.terminalSettings.fontFamily);
+      }
+      if (state.terminalSettings?.claudeFontSize) {
+        setClaudeFontSize(state.terminalSettings.claudeFontSize);
+      }
+      if (state.terminalSettings?.shellFontSize) {
+        setShellFontSize(state.terminalSettings.shellFontSize);
       }
       if (state.terminalSettings?.theme) {
         const tid = state.terminalSettings.theme;
@@ -305,12 +314,25 @@ export function App(): React.ReactElement {
   }, []);
 
   const handleSavePreferences = useCallback(
-    (settings: { fontFamily: string; theme: string }) => {
+    (settings: { fontFamily: string; theme: string; claudeFontSize: number; shellFontSize: number }) => {
       setTerminalFontFamily(settings.fontFamily);
-      setAllTerminalsFontFamily(settings.fontFamily);
+      setClaudeFontSize(settings.claudeFontSize);
+      setShellFontSize(settings.shellFontSize);
+      applyTerminalSettings({
+        fontFamily: settings.fontFamily,
+        claudeFontSize: settings.claudeFontSize,
+        shellFontSize: settings.shellFontSize,
+      });
       setCurrentTheme(settings.theme);
       handlePreviewTheme(settings.theme);
-      window.electronAPI.appSaveState({ terminalSettings: { fontFamily: settings.fontFamily, theme: settings.theme } });
+      window.electronAPI.appSaveState({
+        terminalSettings: {
+          fontFamily: settings.fontFamily,
+          theme: settings.theme,
+          claudeFontSize: settings.claudeFontSize,
+          shellFontSize: settings.shellFontSize,
+        },
+      });
       setShowPreferences(false);
     },
     [handlePreviewTheme]
@@ -415,7 +437,7 @@ export function App(): React.ReactElement {
                   onClose={() => setPtySearch(null)}
                 />
               )}
-              <TerminalView sessionId={activeSessionId} type="pty" fontFamily={terminalFontFamily} />
+              <TerminalView sessionId={activeSessionId} type="pty" fontFamily={terminalFontFamily} fontSize={claudeFontSize} />
             </div>
 
             {/* Shell terminal (collapsible) */}
@@ -429,7 +451,7 @@ export function App(): React.ReactElement {
                     onClose={() => setShellSearch(null)}
                   />
                 )}
-                <TerminalView sessionId={activeSessionId} type="shell" visible={!shellCollapsed} fontFamily={terminalFontFamily} />
+                <TerminalView sessionId={activeSessionId} type="shell" visible={!shellCollapsed} fontFamily={terminalFontFamily} fontSize={shellFontSize} />
               </div>
             </ShellPanel>
           </SplitPane>
@@ -479,6 +501,8 @@ export function App(): React.ReactElement {
         open={showPreferences}
         fontFamily={terminalFontFamily}
         theme={currentTheme}
+        claudeFontSize={claudeFontSize}
+        shellFontSize={shellFontSize}
         onClose={() => setShowPreferences(false)}
         onSave={handleSavePreferences}
         onPreviewTheme={handlePreviewTheme}

--- a/src/renderer/components/PreferencesDialog.tsx
+++ b/src/renderer/components/PreferencesDialog.tsx
@@ -5,14 +5,28 @@ interface PreferencesDialogProps {
   open: boolean;
   fontFamily: string;
   theme: string;
+  claudeFontSize: number;
+  shellFontSize: number;
   onClose: () => void;
-  onSave: (settings: { fontFamily: string; theme: string }) => void;
+  onSave: (settings: { fontFamily: string; theme: string; claudeFontSize: number; shellFontSize: number }) => void;
   onPreviewTheme: (themeId: string) => void;
 }
 
-export function PreferencesDialog({ open, fontFamily, theme, onClose, onSave, onPreviewTheme }: PreferencesDialogProps): React.ReactElement | null {
+const MIN_FONT_SIZE = 8;
+const MAX_FONT_SIZE = 32;
+
+function parseFontSize(value: string): number | null {
+  const n = parseInt(value, 10);
+  if (!Number.isFinite(n)) return null;
+  if (n < MIN_FONT_SIZE || n > MAX_FONT_SIZE) return null;
+  return n;
+}
+
+export function PreferencesDialog({ open, fontFamily, theme, claudeFontSize, shellFontSize, onClose, onSave, onPreviewTheme }: PreferencesDialogProps): React.ReactElement | null {
   const [font, setFont] = useState(fontFamily);
   const [selectedTheme, setSelectedTheme] = useState(theme);
+  const [claudeSize, setClaudeSize] = useState<string>(String(claudeFontSize));
+  const [shellSize, setShellSize] = useState<string>(String(shellFontSize));
   const inputRef = useRef<HTMLInputElement>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
 
@@ -20,8 +34,10 @@ export function PreferencesDialog({ open, fontFamily, theme, onClose, onSave, on
     if (!open) return;
     setFont(fontFamily);
     setSelectedTheme(theme);
+    setClaudeSize(String(claudeFontSize));
+    setShellSize(String(shellFontSize));
     setTimeout(() => inputRef.current?.focus(), 50);
-  }, [open, fontFamily, theme]);
+  }, [open, fontFamily, theme, claudeFontSize, shellFontSize]);
 
   useEffect(() => {
     if (!open) return;
@@ -60,10 +76,19 @@ export function PreferencesDialog({ open, fontFamily, theme, onClose, onSave, on
     onPreviewTheme(id);
   };
 
+  const claudeSizeNum = parseFontSize(claudeSize);
+  const shellSizeNum = parseFontSize(shellSize);
+  const canSave = font.trim().length > 0 && claudeSizeNum !== null && shellSizeNum !== null;
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!font.trim()) return;
-    onSave({ fontFamily: font.trim(), theme: selectedTheme });
+    if (!canSave) return;
+    onSave({
+      fontFamily: font.trim(),
+      theme: selectedTheme,
+      claudeFontSize: claudeSizeNum,
+      shellFontSize: shellSizeNum,
+    });
   };
 
   if (!open) return null;
@@ -153,10 +178,41 @@ export function PreferencesDialog({ open, fontFamily, theme, onClose, onSave, on
             </span>
           </div>
 
+          {/* Font sizes */}
+          <div style={fieldStyle}>
+            <div style={{ display: 'flex', gap: 12 }}>
+              <div style={{ ...fieldStyle, flex: 1 }}>
+                <label style={labelStyle}>Claude Code Font Size</label>
+                <input
+                  type="number"
+                  min={MIN_FONT_SIZE}
+                  max={MAX_FONT_SIZE}
+                  step={1}
+                  style={{ ...inputStyle, borderColor: claudeSizeNum === null ? 'var(--accent-red)' : undefined }}
+                  value={claudeSize}
+                  onChange={(e) => setClaudeSize(e.target.value)}
+                />
+              </div>
+              <div style={{ ...fieldStyle, flex: 1 }}>
+                <label style={labelStyle}>Shell Font Size</label>
+                <input
+                  type="number"
+                  min={MIN_FONT_SIZE}
+                  max={MAX_FONT_SIZE}
+                  step={1}
+                  style={{ ...inputStyle, borderColor: shellSizeNum === null ? 'var(--accent-red)' : undefined }}
+                  value={shellSize}
+                  onChange={(e) => setShellSize(e.target.value)}
+                />
+              </div>
+            </div>
+            <span style={hintStyle}>Between {MIN_FONT_SIZE} and {MAX_FONT_SIZE}.</span>
+          </div>
+
           {/* Preview */}
           <div style={previewContainerStyle}>
             <span style={previewLabelStyle}>Preview</span>
-            <div style={{ ...previewTextStyle, fontFamily: font || undefined }}>
+            <div style={{ ...previewTextStyle, fontFamily: font || undefined, fontSize: claudeSizeNum ?? 13 }}>
               AaBbCc 0123 {'{ }'} =&gt; !=
             </div>
           </div>
@@ -169,9 +225,10 @@ export function PreferencesDialog({ open, fontFamily, theme, onClose, onSave, on
               type="submit"
               style={{
                 ...submitButtonStyle,
-                opacity: font.trim() ? 1 : 0.4,
+                opacity: canSave ? 1 : 0.4,
+                cursor: canSave ? 'pointer' : 'not-allowed',
               }}
-              disabled={!font.trim()}
+              disabled={!canSave}
             >
               Save
             </button>

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -8,12 +8,14 @@ import { getTheme, DEFAULT_THEME_ID } from '../themes';
 import type { XtermColors, SearchDecorations } from '../themes';
 
 const DEFAULT_FONT_FAMILY = "'MesloLGS NF', 'JetBrains Mono', 'IBM Plex Mono', 'SF Mono', 'Fira Code', monospace";
+const DEFAULT_FONT_SIZE = 13;
 
 interface TerminalViewProps {
   sessionId: string | null;
   type: 'pty' | 'shell';
   visible?: boolean;
   fontFamily?: string;
+  fontSize?: number;
 }
 
 interface SearchResult {
@@ -108,11 +110,42 @@ export function terminalClearSearch(type: 'pty' | 'shell', sessionId: string): v
   if (entry) entry.searchAddon.clearDecorations();
 }
 
-/** Update font family on all cached terminal instances. */
-export function setAllTerminalsFontFamily(fontFamily: string): void {
-  for (const entry of terminalCache.values()) {
-    entry.terminal.options.fontFamily = fontFamily;
-    try { entry.fitAddon.fit(); } catch { /* not mounted */ }
+interface TerminalSettingsUpdate {
+  fontFamily?: string;
+  claudeFontSize?: number;
+  shellFontSize?: number;
+}
+
+/**
+ * Apply font family and per-type font size updates to all cached terminals,
+ * refit once per terminal, and notify the corresponding PTY of new dimensions.
+ * Pass only the keys you want to change.
+ */
+export function applyTerminalSettings(update: TerminalSettingsUpdate): void {
+  for (const [key, entry] of terminalCache.entries()) {
+    const isPty = key.startsWith('pty:');
+    const sessionId = key.slice(isPty ? 4 : 6);
+    const resizeMethod = isPty ? 'ptyResize' : 'shellResize';
+    let changed = false;
+
+    try {
+      if (update.fontFamily !== undefined) {
+        entry.terminal.options.fontFamily = update.fontFamily;
+        changed = true;
+      }
+      const newSize = isPty ? update.claudeFontSize : update.shellFontSize;
+      if (newSize !== undefined && newSize > 0) {
+        entry.terminal.options.fontSize = newSize;
+        changed = true;
+      }
+    } catch {
+      // Terminal may have been disposed concurrently; skip it.
+      continue;
+    }
+
+    if (changed) {
+      safeFitAndResize(entry.fitAddon, entry.terminal, sessionId, resizeMethod);
+    }
   }
 }
 
@@ -133,7 +166,7 @@ function safeFitAndResize(
   }
 }
 
-export function TerminalView({ sessionId, type, visible = true, fontFamily }: TerminalViewProps): React.ReactElement {
+export function TerminalView({ sessionId, type, visible = true, fontFamily, fontSize }: TerminalViewProps): React.ReactElement {
   const containerRef = useRef<HTMLDivElement>(null);
   const sessionIdRef = useRef(sessionId);
   sessionIdRef.current = sessionId;
@@ -141,6 +174,7 @@ export function TerminalView({ sessionId, type, visible = true, fontFamily }: Te
   const resizeMethod = type === 'pty' ? 'ptyResize' : 'shellResize' as const;
   const writeMethod = type === 'pty' ? 'ptyWrite' : 'shellWrite' as const;
   const resolvedFont = fontFamily || DEFAULT_FONT_FAMILY;
+  const resolvedFontSize = fontSize && fontSize > 0 ? fontSize : DEFAULT_FONT_SIZE;
 
   const getOrCreateTerminal = useCallback((key: string, sid: string): TerminalEntry => {
     const existing = terminalCache.get(key);
@@ -151,7 +185,7 @@ export function TerminalView({ sessionId, type, visible = true, fontFamily }: Te
       cursorBlink: true,
       cursorStyle: 'bar',
       fontFamily: resolvedFont,
-      fontSize: 13,
+      fontSize: resolvedFontSize,
       lineHeight: 1,
       theme: currentXtermTheme,
       allowTransparency: false,
@@ -195,7 +229,7 @@ export function TerminalView({ sessionId, type, visible = true, fontFamily }: Te
     const entry: TerminalEntry = { terminal, fitAddon, searchAddon, searchResult, mountedIn: null, opened: false, removeDataListener };
     terminalCache.set(key, entry);
     return entry;
-  }, [type, resolvedFont]);
+  }, [type, resolvedFont, resolvedFontSize]);
 
   // Attach terminal to DOM and handle I/O
   useEffect(() => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -97,6 +97,8 @@ export interface ToolkitCommand {
 export interface TerminalSettings {
   fontFamily: string;
   theme: string;
+  claudeFontSize: number;
+  shellFontSize: number;
 }
 
 // ─── App State ───────────────────────────────────────────

--- a/tests/session-store.test.ts
+++ b/tests/session-store.test.ts
@@ -267,6 +267,45 @@ describe('SessionStore', () => {
       expect(defaults.flags).toContain('--enable-auto-mode');
     });
 
+    it('should include default font sizes in terminalSettings when file is missing', () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+      const state = store.loadAppState();
+      expect(state.terminalSettings.claudeFontSize).toBe(13);
+      expect(state.terminalSettings.shellFontSize).toBe(13);
+      expect(typeof state.terminalSettings.fontFamily).toBe('string');
+      expect(typeof state.terminalSettings.theme).toBe('string');
+    });
+
+    it('should backfill missing fontSize fields when state.json predates them', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({
+          windowBounds: { x: 0, y: 0, width: 800, height: 600 },
+          panelSizes: { sidebarWidth: 300, shellHeight: 200, toolkitHeight: 200, shellCollapsed: false },
+          lastActiveSessionId: null,
+          newSessionDefaults: { cwd: '/tmp', flags: [] },
+          terminalSettings: { fontFamily: 'monospace', theme: 'espresso' },
+        })
+      );
+      const state = store.loadAppState();
+      expect(state.terminalSettings.fontFamily).toBe('monospace');
+      expect(state.terminalSettings.theme).toBe('espresso');
+      expect(state.terminalSettings.claudeFontSize).toBe(13);
+      expect(state.terminalSettings.shellFontSize).toBe(13);
+    });
+
+    it('should preserve user-set fontSize values', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({
+          terminalSettings: { fontFamily: 'monospace', theme: 'espresso', claudeFontSize: 16, shellFontSize: 11 },
+        })
+      );
+      const state = store.loadAppState();
+      expect(state.terminalSettings.claudeFontSize).toBe(16);
+      expect(state.terminalSettings.shellFontSize).toBe(11);
+    });
+
     it('should persist --dangerously-skip-permissions in new session defaults', () => {
       vi.mocked(fs.readFileSync).mockReturnValue(
         JSON.stringify({


### PR DESCRIPTION
## Summary
- Adds Claude Code and shell terminal font size controls to the Preferences dialog
- Sizes (8–32) persist independently and apply to existing terminals on save, with a refit + PTY resize so the running process sees the new dimensions
- Backfills missing fontSize fields when loading older `state.json` so upgrades are seamless

Closes #39

## Implementation notes
- `TerminalSettings` gains `claudeFontSize` and `shellFontSize` (default 13)
- New unified `applyTerminalSettings({ fontFamily?, claudeFontSize?, shellFontSize? })` replaces the old per-attribute setters; iterates the cache once, applies font family and per-type font size, refits, then notifies PTY/shell of new cols/rows. Wrapped in try/catch for disposed-terminal safety
- `loadAppState` now deep-merges loaded JSON onto defaults so missing nested fields (including new fontSize) are backfilled
- Preferences dialog disables Save and outlines the input in red when a font size is empty or out of range

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 227/227 passing (3 new tests for default + backfill behavior)
- [ ] Manual: open Preferences, change Claude/shell font sizes, observe live dialog preview, save, confirm both terminals resize correctly and PTY content reflows
- [ ] Manual: restart app, confirm sizes persist
- [ ] Manual: with an older `state.json` lacking fontSize fields, launch app and confirm defaults appear (no crashes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)