### PR TITLE
Open PR URLs in default browser from stage icon

### DIFF
--- a/src/renderer/components/SessionList.tsx
+++ b/src/renderer/components/SessionList.tsx
@@ -15,7 +15,7 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { Session } from '../../shared/types';
-import { STAGE_ICON } from '../stage';
+import { STAGE_ICON, prUrl } from '../stage';
 
 interface SessionListProps {
   sessions: Session[];
@@ -371,9 +371,14 @@ function SessionCard({ session, isActive, isEditing, onClick, onContextMenu, onR
           <span style={{ display: 'flex', alignItems: 'center', gap: 5, overflow: 'hidden', minWidth: 0 }}>
             {session.stage !== 'no-pr' && STAGE_ICON[session.stage] && (() => {
               const { Icon, color, background, tooltip } = STAGE_ICON[session.stage];
+              const clickable = session.pr != null;
               return (
                 <span
                   title={tooltip}
+                  onClick={clickable ? (e) => {
+                    e.stopPropagation();
+                    void window.electronAPI.openExternal(prUrl(session.pr!));
+                  } : undefined}
                   style={{
                     display: 'inline-flex',
                     alignItems: 'center',
@@ -383,6 +388,7 @@ function SessionCard({ session, isActive, isEditing, onClick, onContextMenu, onR
                     background,
                     borderRadius: 'var(--radius-sm)',
                     padding: '2px 3px',
+                    cursor: clickable ? 'pointer' : undefined,
                   }}
                 >
                   <Icon size={13} />

--- a/src/renderer/components/StatusBar.tsx
+++ b/src/renderer/components/StatusBar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { GitBranch } from 'lucide-react';
 import type { Session } from '../../shared/types';
-import { STAGE_ICON } from '../stage';
+import { STAGE_ICON, prUrl } from '../stage';
 
 interface StatusBarProps {
   session: Session | null;
@@ -92,14 +92,19 @@ export function StatusBar({ session }: StatusBarProps): React.ReactElement {
         )}
         {session.stage !== 'no-pr' && STAGE_ICON[session.stage] && (() => {
           const { Icon, color, background, tooltip } = STAGE_ICON[session.stage];
+          const clickable = session.pr != null;
           return (
             <span
               title={tooltip}
+              onClick={clickable ? () => {
+                void window.electronAPI.openExternal(prUrl(session.pr!));
+              } : undefined}
               style={{
                 ...tagStyle,
                 background,
                 color,
                 padding: '3px 5px',
+                cursor: clickable ? 'pointer' : undefined,
               }}
             >
               <Icon size={13} />

--- a/src/renderer/stage.ts
+++ b/src/renderer/stage.ts
@@ -4,7 +4,11 @@ import {
   GitMerge,
   GitPullRequestClosed,
 } from 'lucide-react';
-import type { SessionStage } from '../shared/types';
+import type { PrRef, SessionStage } from '../shared/types';
+
+export function prUrl(pr: PrRef): string {
+  return `https://github.com/${pr.owner}/${pr.repo}/pull/${pr.number}`;
+}
 
 export const STAGE_ICON: Record<Exclude<SessionStage, 'no-pr'>, {
   Icon: typeof GitPullRequestArrow;


### PR DESCRIPTION
## Summary
- Make the stage icon on the session card and the top status bar clickable when the session has an associated PR.
- Clicking opens the GitHub PR in the system's default browser via `shell.openExternal`, instead of being handled inside the Chorus app window.
- Adds a small `prUrl(pr)` helper in `src/renderer/stage.ts` to build the GitHub URL from the existing `PrRef`.

Closes #41

## Test plan
- [x] `npm run build` (tsc --noEmit) passes
- [x] `npm test` — all 227 tests pass
- [ ] Manual: click stage icon on a session card with a PR → opens in default browser, does not switch sessions
- [ ] Manual: click stage icon on the top status bar → opens in default browser
- [ ] Manual: sessions with `stage === 'no-pr'` show no icon (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)