### PR TITLE
Detect 1M context window and align usage with /context

### DIFF
--- a/src/main/hook-server.ts
+++ b/src/main/hook-server.ts
@@ -36,24 +36,33 @@ export interface HookUpdate {
   status: SessionStatus;
   model?: string | null;
   contextUsage?: number | null;
+  contextLimit?: number | null;
 }
 
 export type HookStatusCallback = (sessionId: string, update: HookUpdate) => void;
 export type PrDetectedCallback = (sessionId: string, pr: PrRef) => void;
+/** Returns the previously detected context limit for a session, or null. */
+export type GetContextLimitCallback = (sessionId: string) => number | null;
 
 export class HookServer {
   private server: http.Server | null = null;
   private port = 0;
   private callback: HookStatusCallback;
   private prCallback: PrDetectedCallback | null = null;
+  private getContextLimit: GetContextLimitCallback | null = null;
   /** Tracks which cwd directories have had hooks installed this session. */
   private installedDirs: Set<string> = new Set();
   /** Maps session ID -> transcript path. */
   private transcriptPaths: Map<string, string> = new Map();
 
-  constructor(callback: HookStatusCallback, prCallback?: PrDetectedCallback) {
+  constructor(
+    callback: HookStatusCallback,
+    prCallback?: PrDetectedCallback,
+    getContextLimit?: GetContextLimitCallback,
+  ) {
     this.callback = callback;
     this.prCallback = prCallback ?? null;
+    this.getContextLimit = getContextLimit ?? null;
   }
 
   /** Start the HTTP server on a random available port. */
@@ -226,19 +235,21 @@ export class HookServer {
       const transcriptPath = this.transcriptPaths.get(event.session_id);
       if (transcriptPath) {
         const sessionId = event.session_id;
+        const prevLimit = this.getContextLimit?.(sessionId) ?? null;
         new Promise((r) => setTimeout(r, 500))
           .then(() =>
             Promise.all([
-              readTranscriptMetadata(transcriptPath),
+              readTranscriptMetadata(transcriptPath, prevLimit),
               extractPrFromCreateCall(transcriptPath),
             ]),
           )
           .then(([meta, pr]) => {
-            if (meta.model || meta.contextUsage !== null) {
+            if (meta.model || meta.contextUsage !== null || meta.contextLimit !== null) {
               this.callback(sessionId, {
                 status,
                 model: meta.model ?? undefined,
                 contextUsage: meta.contextUsage ?? undefined,
+                contextLimit: meta.contextLimit ?? undefined,
               });
             }
             if (pr && this.prCallback) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -309,6 +309,8 @@ const hookServer = new HookServer((sessionId, update) => {
   if (update.model !== undefined) updates.model = update.model;
   if (update.contextUsage !== undefined)
     updates.contextUsage = update.contextUsage;
+  if (update.contextLimit !== undefined)
+    updates.contextLimit = update.contextLimit;
 
   // Check flags before updating (need previous status)
   const session = sessionStore.getSession(sessionId);
@@ -353,10 +355,12 @@ const hookServer = new HookServer((sessionId, update) => {
     if (update.model !== undefined) payload.model = update.model;
     if (update.contextUsage !== undefined)
       payload.contextUsage = update.contextUsage;
+    if (update.contextLimit !== undefined)
+      payload.contextLimit = update.contextLimit;
     if (updates.unread !== undefined) payload.unread = updates.unread;
     mainWindow.webContents.send(IpcChannels.SESSION_STATE, payload);
   }
-}, handlePrDetected);
+}, handlePrDetected, (sessionId) => sessionStore.getSession(sessionId)?.contextLimit ?? null);
 
 const ptyManager = new PtyManager();
 
@@ -407,6 +411,7 @@ async function createSessionFromConfig(
     status: "creating",
     model: null,
     contextUsage: null,
+    contextLimit: null,
     gitBranch: null,
     flags: config.flags,
     notifyOnIdle: false,
@@ -953,6 +958,7 @@ function restoreSessions(): void {
         status: "creating",
         model: ps.model ?? null,
         contextUsage: ps.contextUsage ?? null,
+        contextLimit: ps.contextLimit ?? null,
         gitBranch: null,
         flags: ps.flags,
         notifyOnIdle: ps.notifyOnIdle ?? false,

--- a/src/main/session-store.ts
+++ b/src/main/session-store.ts
@@ -170,6 +170,7 @@ export class SessionStore {
         unread: s.unread,
         model: s.model,
         contextUsage: s.contextUsage,
+        contextLimit: s.contextLimit,
         createdAt: s.createdAt,
         lastActiveAt: s.lastActiveAt,
         hasUserInput: s.hasUserInput,

--- a/src/main/transcript-reader.ts
+++ b/src/main/transcript-reader.ts
@@ -1,27 +1,33 @@
 import fs from 'node:fs';
 import type { PrRef } from '../shared/types';
 
-/** Known context window sizes by model family. */
-const CONTEXT_LIMITS: Record<string, number> = {
-  'opus': 200_000,
-  'sonnet': 200_000,
-  'haiku': 200_000,
-};
-
+/**
+ * Default context window — every current Claude model ships with at least 200k.
+ * Some (Opus 4.7, Sonnet 4.5) can be toggled to 1M at runtime via beta header,
+ * but the model id in the transcript looks identical for both modes, so we
+ * cannot tell from the model string alone. See detect1mFromUsage below.
+ */
 const DEFAULT_CONTEXT_LIMIT = 200_000;
+const EXTENDED_CONTEXT_LIMIT = 1_000_000;
 const LINES_PER_CHUNK = 15;
 const MAX_ATTEMPTS = 4;
-
-function getContextLimit(model: string): number {
-  for (const [family, limit] of Object.entries(CONTEXT_LIMITS)) {
-    if (model.includes(family)) return limit;
-  }
-  return DEFAULT_CONTEXT_LIMIT;
-}
 
 export interface TranscriptMetadata {
   model: string | null;
   contextUsage: number | null; // 0-100 percentage
+  contextLimit: number | null; // tokens
+}
+
+/**
+ * One-way detection: if the prompt for a single turn ever exceeded 200k, the
+ * session must be in 1M mode (a 200k session physically cannot hold that many
+ * tokens). Sticky — once detected, callers should keep passing the bumped
+ * limit back in so it persists across restarts.
+ */
+function detectLimit(prevLimit: number | null | undefined, observedInputTokens: number): number {
+  const base = prevLimit && prevLimit > 0 ? prevLimit : DEFAULT_CONTEXT_LIMIT;
+  if (observedInputTokens > DEFAULT_CONTEXT_LIMIT) return EXTENDED_CONTEXT_LIMIT;
+  return base;
 }
 
 /**
@@ -84,10 +90,21 @@ function readTailLines(filePath: string, lineCount: number, skipLines: number): 
  * and estimated context usage from the most recent assistant message.
  *
  * Reads 15 lines from the tail at a time, up to 4 attempts (60 lines max).
+ *
+ * `prevContextLimit` lets the caller persist a previously detected 1M limit
+ * across calls; once a session has been observed to exceed 200k it stays at
+ * 1M even if later turns are smaller (e.g. after /clear).
+ *
+ * The numerator counts only prompt tokens (input + cache_read + cache_creation),
+ * matching what Claude Code's own /context displays — output_tokens are excluded
+ * because they don't carry into the next turn's context budget.
  */
-export async function readTranscriptMetadata(transcriptPath: string): Promise<TranscriptMetadata> {
+export async function readTranscriptMetadata(
+  transcriptPath: string,
+  prevContextLimit?: number | null,
+): Promise<TranscriptMetadata> {
   if (!fs.existsSync(transcriptPath)) {
-    return { model: null, contextUsage: null };
+    return { model: null, contextUsage: null, contextLimit: prevContextLimit ?? null };
   }
 
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
@@ -112,25 +129,25 @@ export async function readTranscriptMetadata(transcriptPath: string): Promise<Tr
       const usage = msg.usage;
 
       let contextUsage: number | null = null;
+      let contextLimit: number | null = prevContextLimit ?? null;
       if (usage) {
         const inputTokens =
           (usage.input_tokens ?? 0) +
           (usage.cache_creation_input_tokens ?? 0) +
           (usage.cache_read_input_tokens ?? 0);
-        const outputTokens = usage.output_tokens ?? 0;
-        const totalTokens = inputTokens + outputTokens;
 
-        if (model && totalTokens > 0) {
-          const limit = getContextLimit(model);
-          contextUsage = Math.min(100, Math.round((totalTokens / limit) * 100));
+        contextLimit = detectLimit(prevContextLimit, inputTokens);
+
+        if (model && inputTokens > 0) {
+          contextUsage = Math.min(100, Math.round((inputTokens / contextLimit) * 100));
         }
       }
 
-      return { model, contextUsage };
+      return { model, contextUsage, contextLimit };
     }
   }
 
-  return { model: null, contextUsage: null };
+  return { model: null, contextUsage: null, contextLimit: prevContextLimit ?? null };
 }
 
 // ─── PR ref extraction ────────────────────────────────────

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -95,6 +95,7 @@ export function App(): React.ReactElement {
                 ...(update.status !== undefined && { status: update.status }),
                 ...(update.model !== undefined && { model: update.model }),
                 ...(update.contextUsage !== undefined && { contextUsage: update.contextUsage }),
+                ...(update.contextLimit !== undefined && { contextLimit: update.contextLimit }),
                 ...(update.gitBranch !== undefined && { gitBranch: update.gitBranch }),
                 ...(update.hasUserInput !== undefined && { hasUserInput: update.hasUserInput }),
                 ...(update.unread !== undefined && { unread: update.unread }),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -30,6 +30,7 @@ export interface Session {
   status: SessionStatus;
   model: string | null;
   contextUsage: number | null;
+  contextLimit: number | null;
   gitBranch: string | null;
   flags: string[];
   notifyOnIdle: boolean;
@@ -54,6 +55,7 @@ export interface SessionStateUpdate {
   status?: SessionStatus;
   model?: string | null;
   contextUsage?: number | null;
+  contextLimit?: number | null;
   gitBranch?: string | null;
   hasUserInput?: boolean;
   unread?: boolean;
@@ -75,6 +77,7 @@ export interface PersistedSession {
   unread: boolean;
   model: string | null;
   contextUsage: number | null;
+  contextLimit: number | null;
   createdAt: number;
   lastActiveAt: number;
   hasUserInput: boolean;

--- a/tests/transcript-reader.test.ts
+++ b/tests/transcript-reader.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { extractPrFromCreateCall } from "../src/main/transcript-reader";
+import { extractPrFromCreateCall, readTranscriptMetadata } from "../src/main/transcript-reader";
 
 function makeTempTranscript(lines: object[]): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "chorus-transcript-"));
@@ -358,5 +358,85 @@ describe("extractPrFromCreateCall", () => {
     ]);
 
     expect(await extractPrFromCreateCall(file)).toBeNull();
+  });
+});
+
+describe("readTranscriptMetadata", () => {
+  let file: string;
+
+  afterEach(() => {
+    if (file) rmFile(file);
+  });
+
+  function assistantEntry(usage: Record<string, number>, model = "claude-opus-4-7") {
+    return {
+      type: "assistant",
+      message: { model, usage },
+    };
+  }
+
+  it("returns nulls when file does not exist", async () => {
+    const meta = await readTranscriptMetadata("/nonexistent.jsonl");
+    expect(meta).toEqual({ model: null, contextUsage: null, contextLimit: null });
+  });
+
+  it("computes percentage from prompt tokens against 200k by default", async () => {
+    file = makeTempTranscript([
+      assistantEntry({
+        input_tokens: 1,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 19_999,
+        output_tokens: 100_000, // should NOT be counted
+      }),
+    ]);
+    const meta = await readTranscriptMetadata(file);
+    expect(meta.model).toBe("claude-opus-4-7");
+    expect(meta.contextLimit).toBe(200_000);
+    // 20_000 / 200_000 = 10%
+    expect(meta.contextUsage).toBe(10);
+  });
+
+  it("excludes output_tokens from the numerator", async () => {
+    file = makeTempTranscript([
+      assistantEntry({
+        input_tokens: 50_000,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        output_tokens: 50_000,
+      }),
+    ]);
+    const meta = await readTranscriptMetadata(file);
+    // Old behavior would have given (50k+50k)/200k = 50%; new gives 25%.
+    expect(meta.contextUsage).toBe(25);
+  });
+
+  it("detects 1M mode when prompt exceeds 200k and bumps the limit", async () => {
+    file = makeTempTranscript([
+      assistantEntry({
+        input_tokens: 250_000,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        output_tokens: 100,
+      }),
+    ]);
+    const meta = await readTranscriptMetadata(file);
+    expect(meta.contextLimit).toBe(1_000_000);
+    // 250_000 / 1_000_000 = 25%
+    expect(meta.contextUsage).toBe(25);
+  });
+
+  it("keeps the 1M limit sticky via prevContextLimit even after small turns", async () => {
+    file = makeTempTranscript([
+      assistantEntry({
+        input_tokens: 100_000, // small prompt, would normally look like 200k mode
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        output_tokens: 0,
+      }),
+    ]);
+    const meta = await readTranscriptMetadata(file, 1_000_000);
+    expect(meta.contextLimit).toBe(1_000_000);
+    // 100k / 1M = 10%
+    expect(meta.contextUsage).toBe(10);
   });
 });


### PR DESCRIPTION
## Summary
- Drop `output_tokens` from the prompt-size numerator so Chorus matches what Claude Code's `/context` shows (output doesn't carry into the next turn's budget).
- Detect 1M mode via high-water-mark: once a turn's prompt exceeds 200k it must be a 1M session, so bump the limit. Persisted per session and sticky across restarts.

Concretely fixes the case where a 1M-mode Opus 4.7 session displaying **12%** in `/context` was showing **59%** in Chorus — wrong numerator (counted output) **and** wrong denominator (assumed 200k).

## Why not something cleaner
Claude Code does not expose the active context window to outside readers (no transcript field, no session-state file, no debug log entry). The only sources are the statusline JSON payload (would require taking over `~/.claude/settings.json`) or the `/context` slash output. Neither is acceptable, so we infer from observed prompt size.

## Caveat
1M sessions still display against a 200k denominator until they cross 200k for the first time — that's the point at which we can prove it's 1M. After that the bumped limit is persisted to `~/.chorus/session-<id>.json`, so subsequent turns and restarts stay correct.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 232/232 passing (5 new tests in `tests/transcript-reader.test.ts` covering: default 200k denominator, output_tokens exclusion, 1M auto-detection on >200k input, 1M stickiness via `prevContextLimit`)
- [ ] Manual: open a 1M-mode session, fill past 200k, confirm Chorus snaps to the 1M denominator and matches `/context`
- [ ] Manual: 200k session — confirm percentage matches `/context`
- [ ] Manual: restart Chorus on a session that was already detected as 1M — confirm `contextLimit` persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)