### PR TITLE
Preload terminals so background sessions capture resume output

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -5,7 +5,7 @@ import { StatusBar } from './components/StatusBar';
 import { ShellPanel } from './components/ShellPanel';
 import { SessionList } from './components/SessionList';
 import { ToolkitPanel } from './components/ToolkitPanel';
-import { TerminalView, disposeTerminal, focusTerminal, getFocusedTerminalInfo, applyTerminalSettings } from './components/TerminalView';
+import { TerminalView, disposeTerminal, focusTerminal, getFocusedTerminalInfo, applyTerminalSettings, preloadTerminal } from './components/TerminalView';
 import { SearchBar } from './components/SearchBar';
 import { NewSessionDialog } from './components/NewSessionDialog';
 import { PreferencesDialog } from './components/PreferencesDialog';
@@ -83,6 +83,28 @@ export function App(): React.ReactElement {
 
     window.electronAPI.toolkitList().then(setToolkitCommands);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ─── Preload terminals for every session ───────────
+  // Background sessions emit PTY data immediately on app restart (claude --resume
+  // dumps conversation history). Without a registered listener, that output is
+  // dropped. preloadTerminal creates a cached xterm + IPC listener per session
+  // so the data is captured even before the user switches to that session.
+  useEffect(() => {
+    for (const s of sessions) {
+      preloadTerminal('pty', s.id, terminalFontFamily, claudeFontSize);
+      preloadTerminal('shell', s.id, terminalFontFamily, shellFontSize);
+    }
+  }, [sessions, terminalFontFamily, claudeFontSize, shellFontSize]);
+
+  // Keep cached terminals' fonts in sync with current settings (handles the
+  // case where preloadTerminal ran with defaults before appGetState resolved).
+  useEffect(() => {
+    applyTerminalSettings({
+      fontFamily: terminalFontFamily,
+      claudeFontSize,
+      shellFontSize,
+    });
+  }, [terminalFontFamily, claudeFontSize, shellFontSize]);
 
   // ─── Session state updates from main ────────────────
   useEffect(() => {

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useCallback } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
@@ -54,6 +54,82 @@ export function setTerminalTheme(xtermTheme: XtermColors, searchDecorations: Sea
 }
 
 // ─── Public API ────────────────────────────────────────────
+
+/**
+ * Create a cached Terminal for the given session if one doesn't exist yet,
+ * and register its PTY/shell data listener immediately. The terminal is not
+ * mounted to the DOM — that happens lazily when TerminalView renders for
+ * this session — but the listener captures output as soon as the PTY emits
+ * it, so background sessions don't lose the resume-time conversation history.
+ */
+export function preloadTerminal(
+  type: 'pty' | 'shell',
+  sessionId: string,
+  fontFamily?: string,
+  fontSize?: number,
+): TerminalEntry {
+  const key = getTerminalKey(type, sessionId);
+  const existing = terminalCache.get(key);
+  if (existing) return existing;
+
+  const terminal = new Terminal({
+    allowProposedApi: true,
+    cursorBlink: true,
+    cursorStyle: 'bar',
+    fontFamily: fontFamily || DEFAULT_FONT_FAMILY,
+    fontSize: fontSize && fontSize > 0 ? fontSize : DEFAULT_FONT_SIZE,
+    lineHeight: 1,
+    theme: currentXtermTheme,
+    allowTransparency: false,
+    scrollback: 10000,
+  });
+
+  const fitAddon = new FitAddon();
+  terminal.loadAddon(fitAddon);
+  terminal.loadAddon(new WebLinksAddon((_event, url) => {
+    window.electronAPI.openExternal(url);
+  }));
+  const searchAddon = new SearchAddon();
+  terminal.loadAddon(searchAddon);
+
+  const searchResult: SearchResult = { resultIndex: -1, resultCount: 0 };
+  searchAddon.onDidChangeResults((e) => {
+    searchResult.resultIndex = e.resultIndex;
+    searchResult.resultCount = e.resultCount;
+  });
+
+  // Register data listener at creation time so background sessions keep receiving output
+  const listenerMethod = type === 'pty' ? 'onPtyData' : 'onShellData';
+  const removeDataListener = window.electronAPI[listenerMethod]((payload) => {
+    if (payload.sessionId === sessionId) {
+      terminal.write(payload.data);
+    }
+  });
+
+  // Sync terminal title changes (e.g. Claude Code /rename) back to Chorus session name
+  if (type === 'pty') {
+    let lastTitle = '';
+    terminal.onTitleChange((title: string) => {
+      const trimmed = title.trim();
+      if (trimmed && trimmed !== lastTitle) {
+        lastTitle = trimmed;
+        window.electronAPI.sessionRename(sessionId, trimmed);
+      }
+    });
+  }
+
+  const entry: TerminalEntry = {
+    terminal,
+    fitAddon,
+    searchAddon,
+    searchResult,
+    mountedIn: null,
+    opened: false,
+    removeDataListener,
+  };
+  terminalCache.set(key, entry);
+  return entry;
+}
 
 /** Focus a cached terminal instance. */
 export function focusTerminal(type: 'pty' | 'shell', sessionId: string): void {
@@ -173,63 +249,6 @@ export function TerminalView({ sessionId, type, visible = true, fontFamily, font
 
   const resizeMethod = type === 'pty' ? 'ptyResize' : 'shellResize' as const;
   const writeMethod = type === 'pty' ? 'ptyWrite' : 'shellWrite' as const;
-  const resolvedFont = fontFamily || DEFAULT_FONT_FAMILY;
-  const resolvedFontSize = fontSize && fontSize > 0 ? fontSize : DEFAULT_FONT_SIZE;
-
-  const getOrCreateTerminal = useCallback((key: string, sid: string): TerminalEntry => {
-    const existing = terminalCache.get(key);
-    if (existing) return existing;
-
-    const terminal = new Terminal({
-      allowProposedApi: true,
-      cursorBlink: true,
-      cursorStyle: 'bar',
-      fontFamily: resolvedFont,
-      fontSize: resolvedFontSize,
-      lineHeight: 1,
-      theme: currentXtermTheme,
-      allowTransparency: false,
-      scrollback: 10000,
-    });
-
-    const fitAddon = new FitAddon();
-    terminal.loadAddon(fitAddon);
-    terminal.loadAddon(new WebLinksAddon((_event, url) => {
-      window.electronAPI.openExternal(url);
-    }));
-    const searchAddon = new SearchAddon();
-    terminal.loadAddon(searchAddon);
-
-    const searchResult: SearchResult = { resultIndex: -1, resultCount: 0 };
-    searchAddon.onDidChangeResults((e) => {
-      searchResult.resultIndex = e.resultIndex;
-      searchResult.resultCount = e.resultCount;
-    });
-
-    // Register data listener at creation time so background sessions keep receiving output
-    const listenerMethod = type === 'pty' ? 'onPtyData' : 'onShellData';
-    const removeDataListener = window.electronAPI[listenerMethod]((payload) => {
-      if (payload.sessionId === sid) {
-        terminal.write(payload.data);
-      }
-    });
-
-    // Sync terminal title changes (e.g. Claude Code /rename) back to Chorus session name
-    if (type === 'pty') {
-      let lastTitle = '';
-      terminal.onTitleChange((title: string) => {
-        const trimmed = title.trim();
-        if (trimmed && trimmed !== lastTitle) {
-          lastTitle = trimmed;
-          window.electronAPI.sessionRename(sid, trimmed);
-        }
-      });
-    }
-
-    const entry: TerminalEntry = { terminal, fitAddon, searchAddon, searchResult, mountedIn: null, opened: false, removeDataListener };
-    terminalCache.set(key, entry);
-    return entry;
-  }, [type, resolvedFont, resolvedFontSize]);
 
   // Attach terminal to DOM and handle I/O
   useEffect(() => {
@@ -237,7 +256,7 @@ export function TerminalView({ sessionId, type, visible = true, fontFamily, font
 
     const key = getTerminalKey(type, sessionId);
     const isNewTerminal = !terminalCache.has(key);
-    const entry = getOrCreateTerminal(key, sessionId);
+    const entry = preloadTerminal(type, sessionId, fontFamily, fontSize);
     const { terminal, fitAddon } = entry;
     const container = containerRef.current;
 
@@ -351,7 +370,7 @@ export function TerminalView({ sessionId, type, visible = true, fontFamily, font
       }
       entry.mountedIn = null;
     };
-  }, [sessionId, type, visible, getOrCreateTerminal, resizeMethod, writeMethod]);
+  }, [sessionId, type, visible, fontFamily, fontSize, resizeMethod, writeMethod]);
 
   return (
     <div


### PR DESCRIPTION
Closes #44

## Summary

- After app restart, background sessions lost the conversation history that `claude --resume` printed because their xterm `Terminal` (and its PTY data listener) wasn't created until the user clicked on the session — by which point the IPC data events had already been dropped.
- Extract terminal creation into `preloadTerminal(type, sessionId, fontFamily?, fontSize?)`, exported from `TerminalView.tsx`. It creates the cached `Terminal` and registers its `pty:data` / `shell:data` listener immediately, without mounting to the DOM.
- In `App.tsx`, call `preloadTerminal` for every session as soon as the session list resolves. Add a font-sync `useEffect` so terminals preloaded with defaults (before `appGetState` resolves) pick up the user's saved font/size.

## Test plan

- [x] `npm run build` (tsc --noEmit) clean
- [x] `npm test` — all 232 tests pass
- [ ] Manual: with 2+ sessions persisted, restart app, click on a background session, scroll up → full `claude --resume` history visible
- [ ] Manual: change terminal font in Preferences → all open terminals update
- [ ] Manual: create a new session in a running app → terminal still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)